### PR TITLE
Updates for 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: julia
 os:
   - linux
 julia:
-  - 0.6.4
-  - 0.7.0
+  - 0.6
+  - 0.7
   - nightly
 notifications:
   email: false
@@ -16,14 +16,6 @@ git:
 matrix:
   allow_failures:
   - julia: nightly
-
-## uncomment and modify the following lines to manually install system packages
-#addons:
-#  apt: # apt-get for linux
-#    packages:
-#    - gfortran
-#before_script: # homebrew for mac
-#  - if [ $TRAVIS_OS_NAME = osx ]; then brew install gcc; fi
 
 ## uncomment the following lines to override the default test script
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ language: julia
 os:
   - linux
 julia:
-  - 0.6
-  - 0.6.1
-  - 0.6.2
+  - 0.6.4
+  - 0.7.0
   - nightly
 notifications:
   email: false
@@ -31,7 +30,7 @@ script:
   - julia -e 'Pkg.clone(pwd()); Pkg.build("MathematicalSystems"); Pkg.clone("https://github.com/JuliaReach/LazySets.jl"); Pkg.test("MathematicalSystems"; coverage=true)'
 
 after_success:
-  - julia -e 'Pkg.add("Documenter"); Pkg.add("GR")'
+  - julia -e 'Pkg.add("Documenter")'
   - julia -e 'cd(Pkg.dir("MathematicalSystems")); include(joinpath("docs", "make.jl"))'
   # code coverage (for both Coveralls and Codecov)
   - julia -e 'Pkg.add("Coverage")'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
 julia:
   - 0.6
   - 0.7
-  - nightly
+  - 1.0
 notifications:
   email: false
 git:
@@ -16,10 +16,6 @@ git:
 matrix:
   allow_failures:
   - julia: nightly
-
-## uncomment the following lines to override the default test script
-script:
-  - julia -e 'Pkg.clone(pwd()); Pkg.build("MathematicalSystems"); Pkg.clone("https://github.com/JuliaReach/LazySets.jl"); Pkg.test("MathematicalSystems"; coverage=true)'
 
 after_success:
   - julia -e 'Pkg.add("Documenter")'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.6
+Compat 1.0.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,18 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 0.6
+  - julia_version: 0.7
+  - julia_version: 1.0
+
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
 
 ## uncomment the following lines to allow failures on nightly julia
 ## (tests will run but not make your overall status red)
 #matrix:
 #  allow_failures:
-#  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-#  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+#  - julia_version: latest
 
 branches:
   only:
@@ -24,24 +26,12 @@ notifications:
     on_build_status_changed: false
 
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# If there's a newer build queued for the same PR, cancel this one
-  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
-        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
-        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
-        throw "There are newer queued builds for this pull request, failing early." }
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.clone(pwd(), \"MathematicalSystems\"); Pkg.build(\"MathematicalSystems\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia -e "Pkg.test(\"MathematicalSystems\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"

--- a/src/MathematicalSystems.jl
+++ b/src/MathematicalSystems.jl
@@ -1,6 +1,10 @@
 __precompile__(true)
 module MathematicalSystems
 
+using Compat
+using Compat.LinearAlgebra
+import Compat.LinearAlgebra: checksquare
+
 #=========================
 Abstract Types for Systems
 ==========================#

--- a/src/continuous.jl
+++ b/src/continuous.jl
@@ -43,6 +43,9 @@ x' = A x.
 struct LinearContinuousSystem{T, MT <: AbstractMatrix{T}} <: AbstractContinuousSystem
     A::MT
 end
+@static if VERSION < v"0.7-"
+    LinearContinuousSystem{T, MT <: AbstractMatrix{T}}(A::MT) = LinearContinuousSystem{T, MT}(A)
+end
 statedim(s::LinearContinuousSystem) = checksquare(s.A)
 inputdim(s::LinearContinuousSystem) = 0
 

--- a/src/continuous.jl
+++ b/src/continuous.jl
@@ -43,8 +43,7 @@ x' = A x.
 struct LinearContinuousSystem{T, MT <: AbstractMatrix{T}} <: AbstractContinuousSystem
     A::MT
 end
-LinearContinuousSystem{T, MT <: AbstractMatrix{T}}(A::MT) = LinearContinuousSystem{T, MT}(A)
-statedim(s::LinearContinuousSystem) = Base.LinAlg.checksquare(s.A)
+statedim(s::LinearContinuousSystem) = checksquare(s.A)
 inputdim(s::LinearContinuousSystem) = 0
 
 """
@@ -63,12 +62,12 @@ x' = A x + B u.
 struct LinearControlContinuousSystem{T, MT <: AbstractMatrix{T}} <: AbstractContinuousSystem
     A::MT
     B::MT
+    function LinearControlContinuousSystem(A::MT, B::MT) where {T, MT <: AbstractMatrix{T}}
+        @assert checksquare(A) == size(B, 1)
+        return new{T, MT}(A, B)
+    end
 end
-function LinearControlContinuousSystem{T, MT <: AbstractMatrix{T}}(A::MT, B::MT)
-    @assert Base.LinAlg.checksquare(A) == size(B, 1)
-    return LinearControlContinuousSystem{T, MT}(A, B)
-end
-statedim(s::LinearControlContinuousSystem) = Base.LinAlg.checksquare(s.A)
+statedim(s::LinearControlContinuousSystem) = checksquare(s.A)
 inputdim(s::LinearControlContinuousSystem) = size(s.B, 2)
 
 """
@@ -88,8 +87,7 @@ struct ConstrainedLinearContinuousSystem{T, MT <: AbstractMatrix{T}, ST} <: Abst
     A::MT
     X::ST
 end
-ConstrainedLinearContinuousSystem{T, MT <: AbstractMatrix{T}, ST}(A::MT, X::ST) = ConstrainedLinearContinuousSystem{T, MT, ST}(A, X)
-statedim(s::ConstrainedLinearContinuousSystem) = Base.LinAlg.checksquare(s.A)
+statedim(s::ConstrainedLinearContinuousSystem) = checksquare(s.A)
 stateset(s::ConstrainedLinearContinuousSystem) = s.X
 inputdim(s::ConstrainedLinearContinuousSystem) = 0
 
@@ -113,12 +111,12 @@ struct ConstrainedLinearControlContinuousSystem{T, MT <: AbstractMatrix{T}, ST, 
     B::MT
     X::ST
     U::UT
+    function ConstrainedLinearControlContinuousSystem(A::MT, B::MT, X::ST, U::UT) where {T, MT <: AbstractMatrix{T}, ST, UT}
+        @assert checksquare(A) == size(B, 1)
+        return new{T, MT, ST, UT}(A, B, X, U)
+    end
 end
-function ConstrainedLinearControlContinuousSystem{T, MT <: AbstractMatrix{T}, ST, UT}(A::MT, B::MT, X::ST, U::UT)
-    @assert Base.LinAlg.checksquare(A) == size(B, 1)
-    return ConstrainedLinearControlContinuousSystem{T, MT, ST, UT}(A, B, X, U)
-end
-statedim(s::ConstrainedLinearControlContinuousSystem) = Base.LinAlg.checksquare(s.A)
+statedim(s::ConstrainedLinearControlContinuousSystem) = checksquare(s.A)
 stateset(s::ConstrainedLinearControlContinuousSystem) = s.X
 inputdim(s::ConstrainedLinearControlContinuousSystem) = size(s.B, 2)
 inputset(s::ConstrainedLinearControlContinuousSystem) = s.U
@@ -139,10 +137,10 @@ E x' = A x.
 struct LinearAlgebraicContinuousSystem{T, MT <: AbstractMatrix{T}} <: AbstractContinuousSystem
     A::MT
     E::MT
-end
-function LinearAlgebraicContinuousSystem{T, MT <: AbstractMatrix{T}}(A::MT, E::MT)
-    @assert size(A) == size(E)
-    return LinearAlgebraicContinuousSystem{T, MT}(A, E)
+    function LinearAlgebraicContinuousSystem(A::MT, E::MT) where {T, MT <: AbstractMatrix{T}}
+        @assert size(A) == size(E)
+        return new{T, MT}(A, E)
+    end
 end
 statedim(s::LinearAlgebraicContinuousSystem) = size(s.A, 1)
 inputdim(s::LinearAlgebraicContinuousSystem) = 0
@@ -165,10 +163,10 @@ struct ConstrainedLinearAlgebraicContinuousSystem{T, MT <: AbstractMatrix{T}, ST
     A::MT
     E::MT
     X::ST
-end
-function ConstrainedLinearAlgebraicContinuousSystem{T, MT <: AbstractMatrix{T}, ST}(A::MT, E::MT, X::ST)
-    @assert size(A) == size(E)
-    return ConstrainedLinearAlgebraicContinuousSystem{T, MT, ST}(A, E, X)
+    function ConstrainedLinearAlgebraicContinuousSystem(A::MT, E::MT, X::ST) where {T, MT <: AbstractMatrix{T}, ST}
+        @assert size(A) == size(E)
+        return new{T, MT, ST}(A, E, X)
+    end
 end
 statedim(s::ConstrainedLinearAlgebraicContinuousSystem) = size(s.A, 1)
 stateset(s::ConstrainedLinearAlgebraicContinuousSystem) = s.X

--- a/src/continuous.jl
+++ b/src/continuous.jl
@@ -90,6 +90,9 @@ struct ConstrainedLinearContinuousSystem{T, MT <: AbstractMatrix{T}, ST} <: Abst
     A::MT
     X::ST
 end
+@static if VERSION < v"0.7-"
+    ConstrainedLinearContinuousSystem{T, MT <: AbstractMatrix{T}, ST}(A::MT, X::ST) = ConstrainedLinearContinuousSystem{T, MT, ST}(A, X)
+end
 statedim(s::ConstrainedLinearContinuousSystem) = checksquare(s.A)
 stateset(s::ConstrainedLinearContinuousSystem) = s.X
 inputdim(s::ConstrainedLinearContinuousSystem) = 0

--- a/src/discrete.jl
+++ b/src/discrete.jl
@@ -43,8 +43,7 @@ x_{k+1} = A x_k.
 struct LinearDiscreteSystem{T, MT <: AbstractMatrix{T}} <: AbstractDiscreteSystem
     A::MT
 end
-LinearDiscreteSystem{T, MT <: AbstractMatrix{T}}(A::MT) = LinearDiscreteSystem{T, MT}(A)
-statedim(s::LinearDiscreteSystem) = Base.LinAlg.checksquare(s.A)
+statedim(s::LinearDiscreteSystem) = checksquare(s.A)
 inputdim(s::LinearDiscreteSystem) = 0
 
 """
@@ -63,12 +62,12 @@ x_{k+1} = A x_k + B u_k.
 struct LinearControlDiscreteSystem{T, MT <: AbstractMatrix{T}} <: AbstractDiscreteSystem
     A::MT
     B::MT
+    function LinearControlDiscreteSystem(A::MT, B::MT) where {T, MT <: AbstractMatrix{T}}
+        @assert checksquare(A) == size(B, 1)
+        return new{T, MT}(A, B)
+    end
 end
-function LinearControlDiscreteSystem{T, MT <: AbstractMatrix{T}}(A::MT, B::MT)
-    @assert Base.LinAlg.checksquare(A) == size(B, 1)
-    return LinearControlDiscreteSystem{T, MT}(A, B)
-end
-statedim(s::LinearControlDiscreteSystem) = Base.LinAlg.checksquare(s.A)
+statedim(s::LinearControlDiscreteSystem) = checksquare(s.A)
 inputdim(s::LinearControlDiscreteSystem) = size(s.B, 2)
 
 """
@@ -88,8 +87,7 @@ struct ConstrainedLinearDiscreteSystem{T, MT <: AbstractMatrix{T}, ST} <: Abstra
     A::MT
     X::ST
 end
-ConstrainedLinearDiscreteSystem{T, MT <: AbstractMatrix{T}, ST}(A::MT, X::ST) = ConstrainedLinearDiscreteSystem{T, MT, ST}(A, X)
-statedim(s::ConstrainedLinearDiscreteSystem) = Base.LinAlg.checksquare(s.A)
+statedim(s::ConstrainedLinearDiscreteSystem) = checksquare(s.A)
 stateset(s::ConstrainedLinearDiscreteSystem) = s.X
 inputdim(s::ConstrainedLinearDiscreteSystem) = 0
 
@@ -113,12 +111,12 @@ struct ConstrainedLinearControlDiscreteSystem{T, MT <: AbstractMatrix{T}, ST, UT
     B::MT
     X::ST
     U::UT
+    function ConstrainedLinearControlDiscreteSystem(A::MT, B::MT, X::ST, U::UT) where {T, MT <: AbstractMatrix{T}, ST, UT}
+        @assert checksquare(A) == size(B, 1)
+        return new{T, MT, ST, UT}(A, B, X, U)
+    end
 end
-function ConstrainedLinearControlDiscreteSystem{T, MT <: AbstractMatrix{T}, ST, UT}(A::MT, B::MT, X::ST, U::UT)
-    @assert Base.LinAlg.checksquare(A) == size(B, 1)
-    return ConstrainedLinearControlDiscreteSystem{T, MT, ST, UT}(A, B, X, U)
-end
-statedim(s::ConstrainedLinearControlDiscreteSystem) = Base.LinAlg.checksquare(s.A)
+statedim(s::ConstrainedLinearControlDiscreteSystem) = checksquare(s.A)
 stateset(s::ConstrainedLinearControlDiscreteSystem) = s.X
 inputdim(s::ConstrainedLinearControlDiscreteSystem) = size(s.B, 2)
 inputset(s::ConstrainedLinearControlDiscreteSystem) = s.U
@@ -139,10 +137,10 @@ E x_{k+1} = A x_k.
 struct LinearAlgebraicDiscreteSystem{T, MT <: AbstractMatrix{T}} <: AbstractDiscreteSystem
     A::MT
     E::MT
-end
-function LinearAlgebraicDiscreteSystem{T, MT <: AbstractMatrix{T}}(A::MT, E::MT)
-    @assert size(A) == size(E)
-    return LinearAlgebraicDiscreteSystem{T, MT}(A, E)
+    function LinearAlgebraicDiscreteSystem(A::MT, E::MT) where {T, MT <: AbstractMatrix{T}}
+        @assert size(A) == size(E)
+        return new{T, MT}(A, E)
+    end
 end
 statedim(s::LinearAlgebraicDiscreteSystem) = size(s.A, 1)
 inputdim(s::LinearAlgebraicDiscreteSystem) = 0
@@ -165,10 +163,10 @@ struct ConstrainedLinearAlgebraicDiscreteSystem{T, MT <: AbstractMatrix{T}, ST} 
     A::MT
     E::MT
     X::ST
-end
-function ConstrainedLinearAlgebraicDiscreteSystem{T, MT <: AbstractMatrix{T}, ST}(A::MT, E::MT, X::ST)
-    @assert size(A) == size(E)
-    return ConstrainedLinearAlgebraicDiscreteSystem{T, MT, ST}(A, E, X)
+    function ConstrainedLinearAlgebraicDiscreteSystem(A::MT, E::MT, X::ST) where {T, MT <: AbstractMatrix{T}, ST}
+        @assert size(A) == size(E)
+        return new{T, MT, ST}(A, E, X)
+    end
 end
 statedim(s::ConstrainedLinearAlgebraicDiscreteSystem) = size(s.A, 1)
 stateset(s::ConstrainedLinearAlgebraicDiscreteSystem) = s.X

--- a/src/discrete.jl
+++ b/src/discrete.jl
@@ -43,6 +43,9 @@ x_{k+1} = A x_k.
 struct LinearDiscreteSystem{T, MT <: AbstractMatrix{T}} <: AbstractDiscreteSystem
     A::MT
 end
+@static if VERSION < v"0.7-"
+    LinearDiscreteSystem{T, MT <: AbstractMatrix{T}}(A::MT) = LinearDiscreteSystem{T, MT}(A)
+end
 statedim(s::LinearDiscreteSystem) = checksquare(s.A)
 inputdim(s::LinearDiscreteSystem) = 0
 
@@ -86,6 +89,9 @@ x_{k+1} = A x_k, x_k ∈ \\mathcal{X}.
 struct ConstrainedLinearDiscreteSystem{T, MT <: AbstractMatrix{T}, ST} <: AbstractDiscreteSystem
     A::MT
     X::ST
+end
+@static if VERSION < v"0.7-"
+    ConstrainedLinearDiscreteSystem{T, MT <: AbstractMatrix{T}, ST}(A::MT, X::ST) = ConstrainedLinearDiscreteSystem{T, MT, ST}(A, X)
 end
 statedim(s::ConstrainedLinearDiscreteSystem) = checksquare(s.A)
 stateset(s::ConstrainedLinearDiscreteSystem) = s.X

--- a/src/inputs.jl
+++ b/src/inputs.jl
@@ -71,9 +71,17 @@ end
 
 Base.eltype(::Type{ConstantInput{UT}}) where {UT} = UT
 
-Base.start(::ConstantInput) = nothing
-Base.next(input::ConstantInput, state) = (input.U, nothing)
-Base.done(::ConstantInput, state) = false
+@static if VERSION < v"0.7-"
+    @eval begin
+            Base.start(::ConstantInput) = nothing
+            Base.next(input::ConstantInput, state) = (input.U, nothing)
+            Base.done(::ConstantInput, state) = false
+           end
+else
+    @eval begin
+            Base.iterate(input::ConstantInput, state::Void=nothing) = (input.U, state)
+    end
+end
 
 Base.IteratorSize(::Type{<:ConstantInput}) = Base.IsInfinite()
 Base.IteratorEltype(::Type{<:ConstantInput}) = Base.HasEltype()
@@ -187,9 +195,19 @@ end
 
 Base.eltype(::Type{VaryingInput{UT}}) where {UT} = UT
 
-Base.start(::VaryingInput) = 1
-Base.next(input::VaryingInput, state) = (input.U[state], state + 1)
-Base.done(input::VaryingInput, state) = state > length(input.U)
+@static if VERSION < v"0.7-"
+    @eval begin
+            Base.start(::VaryingInput) = 1
+            Base.next(input::VaryingInput, state) = (input.U[state], state + 1)
+            Base.done(input::VaryingInput, state) = state > length(input.U)
+    end
+else
+    @eval begin
+            Base.iterate(input::VaryingInput, state::Int=1) =
+                state > length(input.U) ? nothing : (input.U[state], state + 1)
+    end
+end
+
 
 Base.length(input::VaryingInput) = length(input.U)
 

--- a/src/inputs.jl
+++ b/src/inputs.jl
@@ -73,13 +73,13 @@ Base.eltype(::Type{ConstantInput{UT}}) where {UT} = UT
 
 @static if VERSION < v"0.7-"
     @eval begin
-            Base.start(::ConstantInput) = nothing
-            Base.next(input::ConstantInput, state) = (input.U, nothing)
-            Base.done(::ConstantInput, state) = false
-           end
+        Base.start(::ConstantInput) = nothing
+        Base.next(input::ConstantInput, state) = (input.U, nothing)
+        Base.done(::ConstantInput, state) = false
+    end
 else
     @eval begin
-            Base.iterate(input::ConstantInput, state::Void=nothing) = (input.U, state)
+        Base.iterate(input::ConstantInput, state::Nothing=nothing) = (input.U, state)
     end
 end
 

--- a/test/continuous.jl
+++ b/test/continuous.jl
@@ -43,7 +43,7 @@ end
 
 @testset "Continuous constrained linear control system" begin
     A = [1. 1; 1 -1]
-    B = [0.5 1.5]'
+    B = Matrix([0.5 1.5]')
     X = Line([1., -1], 0.)
     U = Hyperrectangle(low=[0.9, 0.9], high=[1.1, 1.2])
     s = ConstrainedLinearControlContinuousSystem(A, B, X, U)

--- a/test/discrete.jl
+++ b/test/discrete.jl
@@ -78,7 +78,11 @@ end
     U = ConstantInput(Hyperrectangle(low=[0.9, 0.9], high=[1.1, 1.2]))
     s = ConstrainedLinearControlDiscreteSystem(A, B, X, U)
     s = ConstrainedLinearControlDiscreteSystem(A, B, X, U)
-    @test next(s.U, 1)[1] isa Hyperrectangle
+    if VERSION < v"0.7-"
+        @test next(s.U, 1)[1] isa Hyperrectangle
+    else
+        @test iterate(s.U)[1] isa Hyperrectangle
+    end
 end
 
 @testset "Varying input in a discrete constrained linear control system" begin

--- a/test/discrete.jl
+++ b/test/discrete.jl
@@ -43,7 +43,7 @@ end
 
 @testset "Discrete constrained linear control system" begin
     A = [1. 1; 1 -1]
-    B = [0.5 1.5]'
+    B = Matrix([0.5 1.5]')
     X = Line([1., -1], 0.)
     U = Hyperrectangle(low=[0.9, 0.9], high=[1.1, 1.2])
     s = ConstrainedLinearControlDiscreteSystem(A, B, X, U)
@@ -73,7 +73,7 @@ end
 
 @testset "Constant input in a discrete constrained linear control system" begin
     A = [1. 1; 1 -1]
-    B = [0.5 1.5]'
+    B = Matrix([0.5 1.5]')
     X = Line([1., -1], 0.)
     U = ConstantInput(Hyperrectangle(low=[0.9, 0.9], high=[1.1, 1.2]))
     s = ConstrainedLinearControlDiscreteSystem(A, B, X, U)
@@ -83,7 +83,7 @@ end
 
 @testset "Varying input in a discrete constrained linear control system" begin
     A = [1. 1; 1 -1]
-    B = [0.5 1.5]'
+    B = Matrix([0.5 1.5]')
     X = Line([1., -1], 0.)
     U = VaryingInput([Hyperrectangle(low=[0.9, 0.9], high=[1.1, 1.2]),
                       Hyperrectangle(low=[0.99, 0.99], high=[1.0, 1.1])])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using MathematicalSystems, LazySets, TypedPolynomials
-using Base.Test
+using Compat, Compat.Test
 
 include("continuous.jl")
 include("discrete.jl")


### PR DESCRIPTION
Closes #28.

- [x] use inner constructors if necessary
- [x] fix some doctests with `Matrix(::Transpose)`, that were failing because `A::MT` and `B::MT` fields are of the same type
-  [x] update travis script and add Compat to REQUIRE
- [x] new iteration protocol for `inputs.jl`
- [x] fix 0.6 (default constructors)