### PR TITLE
Update docs script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
       julia: 1.0
       os: linux
       script:
-        - julia --project=docs/ -e 'using Pkg; Pkg.instantiate();
-                                    Pkg.develop(PackageSpec(path=pwd()))'
+        - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));
+                                               Pkg.instantiate();'
         - julia --project=docs/ docs/make.jl
       after_success: skip

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -18,7 +18,6 @@ makedocs(
 deploydocs(
     repo = "github.com/JuliaReach/MathematicalSystems.jl.git",
     target = "build",
-    osname = "linux",
     deps = nothing,
     make = nothing
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,7 +3,7 @@ using Documenter, MathematicalSystems
 makedocs(
     doctest = true,  # use this flag to skip doctests (saves time!)
     modules = [MathematicalSystems],
-    format = Documenter.HTML(),
+    format = :html,
     assets = ["assets/juliareach.css"],
     sitename = "MathematicalSystems.jl",
     pages = [

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,7 +3,7 @@ using Documenter, MathematicalSystems
 makedocs(
     doctest = true,  # use this flag to skip doctests (saves time!)
     modules = [MathematicalSystems],
-    format = :html,
+    format = Documenter.HTML(),
     assets = ["assets/juliareach.css"],
     sitename = "MathematicalSystems.jl",
     pages = [
@@ -19,7 +19,6 @@ deploydocs(
     repo = "github.com/JuliaReach/MathematicalSystems.jl.git",
     target = "build",
     osname = "linux",
-    julia  = "1.0",
     deps = nothing,
     make = nothing
 )


### PR DESCRIPTION
This PR fixes 3 deprecations suggested by `Documenter`:

Current `master`:

```julia
$ julia1 --color=yes docs/make.jl
┌ Warning: `format = :html` is deprecated, use `format = Documenter.HTML()` instead.
│   caller = ip:0x0
└ @ Core :-1
[ Info: SetupBuildDirectory: setting up build directory.
[ Info: ExpandTemplates: expanding markdown templates.
[ Info: CrossReferences: building cross-references.
[ Info: CheckDocument: running document checks.
[ Info: Populate: populating indices.
[ Info: RenderDocument: rendering document.
┌ Warning: the `julia` keyword argument to `Documenter.deploydocs` is removed. Use Travis Build Stages for determining from where to deploy instead. See the section a
bout Hosting in the Documenter manual for more details.
│   caller = ip:0x0
└ @ Core :-1
[ Info: skipping docs deployment.
```

After fixing those two:

```julia
$ julia1 --color=yes docs/make.jl
[ Info: SetupBuildDirectory: setting up build directory.
[ Info: ExpandTemplates: expanding markdown templates.
[ Info: CrossReferences: building cross-references.
[ Info: CheckDocument: running document checks.
[ Info: Populate: populating indices.
[ Info: RenderDocument: rendering document.
┌ Warning: the `osname` keyword argument to `Documenter.deploydocs` is removed. Use Travis Build Stages for determining from where to deploy instead. See the section
about Hosting in the Documenter manual for more details.
│   caller = ip:0x0
└ @ Core :-1
[ Info: skipping docs deployment.
```

After fixing `osname`:

```julia
$ julia1 --color=yes docs/make.jl
[ Info: SetupBuildDirectory: setting up build directory.
[ Info: ExpandTemplates: expanding markdown templates.
[ Info: CrossReferences: building cross-references.
[ Info: CheckDocument: running document checks.
[ Info: Populate: populating indices.
[ Info: RenderDocument: rendering document.
┌ Info: Deployment criteria:
│ - ✔ ENV["TRAVIS_REPO_SLUG"]="" occurs in repo="github.com/JuliaReach/MathematicalSystems.jl.git"
│ - ✘ ENV["TRAVIS_PULL_REQUEST"]="" is "false"
│ - ✔ ENV["TRAVIS_TAG"]="" is (i) empty or (ii) a valid VersionNumber
│ - ✘ ENV["TRAVIS_BRANCH"]="" matches devbranch="master (if tag is empty)
│ - ✘ ENV["DOCUMENTER_KEY"] exists
└ Deploying: ✘
```
