### PR TITLE
Add more maps 

### DIFF
--- a/docs/src/lib/types.md
+++ b/docs/src/lib/types.md
@@ -84,8 +84,11 @@ VaryingInput
 ```@docs
 AbstractMap
 IdentityMap
+ConstrainedIdentityMap
 LinearMap
+ConstrainedLinearMap
 AffineMap
+ConstrainedAffineMap
 LinearControlMap
 ConstrainedLinearControlMap
 AffineControlMap

--- a/src/maps.jl
+++ b/src/maps.jl
@@ -250,7 +250,7 @@ struct AffineControlMap{T, MTA <: AbstractMatrix{T}, MTB <: AbstractMatrix{T}, V
 end
 statedim(m::AffineControlMap) = size(m.A, 2)
 outputdim(m::AffineControlMap) = size(m.A, 1)
-inputdim(m::LinearControlMap) = size(m.B, 1)
+inputdim(m::AffineControlMap) = size(m.B, 1)
 islinear(::AffineControlMap) = false
 isaffine(::AffineControlMap) = true
 apply(m::AffineControlMap, x, u) = m.A * x + m.B * u + m.c

--- a/src/maps.jl
+++ b/src/maps.jl
@@ -269,7 +269,7 @@ An affine control map with state and input constraints,
 - `A` -- matrix
 - `B` -- matrix
 - `c` -- vector
-- `X` -- input constraints
+- `X` -- state constraints
 - `U` -- input constraints
 """
 struct ConstrainedAffineControlMap{T, MTA<:AbstractMatrix{T}, MTB<:AbstractMatrix{T}, VT<:AbstractVector{T}, ST, UT} <: AbstractMap
@@ -286,6 +286,7 @@ end
 statedim(m::ConstrainedAffineControlMap) = size(m.A, 2)
 stateset(m::ConstrainedAffineControlMap) = m.X
 inputdim(m::ConstrainedAffineControlMap) = size(m.B, 2)
+inputset(m::ConstrainedAffineControlMap) = m.U
 outputdim(m::ConstrainedAffineControlMap) = size(m.A, 1)
 islinear(::ConstrainedAffineControlMap) = false
 isaffine(::ConstrainedAffineControlMap) = true

--- a/src/outputs.jl
+++ b/src/outputs.jl
@@ -77,7 +77,7 @@ continuous system and the output map is a constrained linear control map.
 """
 function LinearTimeInvariantSystem(A, B, C, D, X, U)
     system = ConstrainedLinearControlContinuousSystem(A, B, X, U)
-    outputmap = ConstrainedLinearControlMap(C, D, U)
+    outputmap = ConstrainedLinearControlMap(C, D, X, U)
     return SystemWithOutput(system, outputmap)
 end
 

--- a/src/systems.jl
+++ b/src/systems.jl
@@ -22,6 +22,10 @@ Trivial identity continuous-time system of the form:
 ```math
     x' = 0.
 ```
+
+### Fields
+
+- `statedim` -- number of state variables
 """
 ContinuousIdentitySystem
 
@@ -32,6 +36,10 @@ Trivial identity discrete-time system of the form:
 ```math
     x_{k+1} = x_k.
 ```
+
+### Fields
+
+- `statedim` -- number of state variables
 """
 DiscreteIdentitySystem
 
@@ -58,6 +66,11 @@ Trivial identity continuous-time system with state constraints of the form:
 ```math
     x' = 0, x(t) ∈ \\mathcal{X}.
 ```
+
+### Fields
+
+- `statedim` -- number of state variables
+- `X`        -- state constraints
 """
 ConstrainedContinuousIdentitySystem
 
@@ -69,6 +82,11 @@ Trivial identity discrete-time system with state constraints of the form:
 ```math
     x_{k+1} = x_k, x_k ∈ \\mathcal{X}.
 ```
+
+### Fields
+
+- `statedim` -- number of state variables
+- `X`        -- state constraints
 """
 ConstrainedDiscreteIdentitySystem
 
@@ -343,6 +361,7 @@ end
     ConstrainedAffineControlContinuousSystem
 
 Continuous-time affine control system with state constraints of the form:
+
 ```math
     x' = A x + B u + c, x(t) ∈ \\mathcal{X}, u(t) ∈ \\mathcal{U} \\text{ for all } t,
 ```

--- a/test/maps.jl
+++ b/test/maps.jl
@@ -54,14 +54,15 @@ end
 @testset "Constrained linear control map" begin
     A = [1. 1; 1 -1]
     B = Matrix([0.5 1.5]')
+    X = Line([1., -1], 0.)
     U = Interval(-1, 1)
-    m = ConstrainedLinearControlMap(A, B, U)
+    m = ConstrainedLinearControlMap(A, B, X, U)
     @test outputdim(m) == 2
     @test islinear(m) && isaffine(m)
 
     # applying the affine map on a vector
-    x = ones(2)
-    u = [1/2]
+    x = ones(2) # (it is not checked that x ∈ X in this library)
+    u = [1/2]   # same for u ∈ U
     @test apply(m, x, u) == A*x + B*u
 end
 
@@ -82,9 +83,10 @@ end
 @testset "Constrained affine control map" begin
     A = [1. 1; 1 -1]
     B = Matrix([0.5 1.5]')
+    X = Line([1., -1], 0.) # line x = y
     c = [0.5, 0.5]
     U = Interval(-1, 1)
-    m = ConstrainedAffineControlMap(A, B, c, U)
+    m = ConstrainedAffineControlMap(A, B, c, X, U)
     @test outputdim(m) == 2
     @test !islinear(m) && isaffine(m)
 


### PR DESCRIPTION
Closes #64.

This PR adds the missing combinations of specialized map types, see the table in #60.

I also changed the behavior of some of the existing ones to match exactly the names of the corresponding systems. For example, in `master` we have that `ConstrainedAffineControlMap` has input constraints but no state constraints, althugh `ConstrainedAffineControlContinuousSystem` has both input and state constraints; then i let `ConstrainedAffineControlMap` to also have state constraints in this branch.

There are also minor docstrings tweaks to make them uniform throughout.