### PR TITLE
Export AbstractMap

### DIFF
--- a/src/MathematicalSystems.jl
+++ b/src/MathematicalSystems.jl
@@ -81,7 +81,8 @@ include("inputs.jl")
 #==================================
 Maps
 ===================================#
-export outputmap,
+export AbstractMap,
+       outputmap,
        outputdim,
        IdentityMap,
        LinearMap,


### PR DESCRIPTION
We export `AbstractSystem`, so we should export both (or none).