### PR TITLE
Remove N in I(λ, n) constructor

### DIFF
--- a/src/identity.jl
+++ b/src/identity.jl
@@ -101,4 +101,4 @@ end
 # callable identity matrix
 LinearAlgebra.I(n::Int, N=Float64) = IdentityMultiple(one(N)*I, n)
 
-LinearAlgebra.I(λ::Number, n::Int, N=Float64) = IdentityMultiple(N(λ)*I, n)
+LinearAlgebra.I(λ::Number, n::Int) = IdentityMultiple(λ*I, n)


### PR DESCRIPTION
This fixes the error in a doctest (see [this line](https://travis-ci.org/JuliaReach/MathematicalSystems.jl/jobs/506938952#L490)). Moreover, i think that it is unnecessary to pass both the value `λ` and `N`.