### PR TITLE
Add iscontrolled and isconstrained trait

### DIFF
--- a/docs/src/lib/types.md
+++ b/docs/src/lib/types.md
@@ -43,8 +43,8 @@ ConstrainedBlackBoxContinuousSystem
 ConstrainedBlackBoxControlContinuousSystem
 NoisyConstrainedLinearContinuousSystem
 NoisyConstrainedLinearControlContinuousSystem
-NoisyConstrainedBlackBoxControlContinuousSystem
 NoisyConstrainedAffineControlContinuousSystem
+NoisyConstrainedBlackBoxControlContinuousSystem
 ```
 
 ## Discrete Systems

--- a/docs/src/lib/types.md
+++ b/docs/src/lib/types.md
@@ -41,6 +41,10 @@ ConstrainedPolynomialContinuousSystem
 BlackBoxContinuousSystem
 ConstrainedBlackBoxContinuousSystem
 ConstrainedBlackBoxControlContinuousSystem
+NoisyConstrainedLinearContinuousSystem
+NoisyConstrainedLinearControlContinuousSystem
+NoisyConstrainedBlackBoxControlContinuousSystem
+NoisyConstrainedAffineControlContinuousSystem
 ```
 
 ## Discrete Systems
@@ -62,6 +66,10 @@ ConstrainedPolynomialDiscreteSystem
 BlackBoxDiscreteSystem
 ConstrainedBlackBoxDiscreteSystem
 ConstrainedBlackBoxControlDiscreteSystem
+NoisyConstrainedLinearDiscreteSystem
+NoisyConstrainedLinearControlDiscreteSystem
+NoisyConstrainedAffineControlDiscreteSystem
+NoisyConstrainedBlackBoxControlDiscreteSystem
 ```
 
 ## Identity operator

--- a/src/MathematicalSystems.jl
+++ b/src/MathematicalSystems.jl
@@ -21,6 +21,9 @@ export AbstractSystem,
        stateset,
        inputdim,
        inputset,
+       noisedim,
+       noiseset,
+       isnoisy,
        islinear,
        isaffine
 
@@ -64,7 +67,15 @@ export DiscreteIdentitySystem,
        ConstrainedPolynomialDiscreteSystem,
        BlackBoxDiscreteSystem,
        ConstrainedBlackBoxDiscreteSystem,
-       ConstrainedBlackBoxControlDiscreteSystem
+       ConstrainedBlackBoxControlDiscreteSystem,
+       NoisyConstrainedLinearContinuousSystem,
+       NoisyConstrainedLinearDiscreteSystem,
+       NoisyConstrainedLinearControlContinuousSystem,
+       NoisyConstrainedLinearControlDiscreteSystem,
+       NoisyConstrainedAffineControlContinuousSystem,
+       NoisyConstrainedAffineControlDiscreteSystem,
+       NoisyConstrainedBlackBoxControlContinuousSystem,
+       NoisyConstrainedBlackBoxControlDiscreteSystem
 
 include("systems.jl")
 

--- a/src/MathematicalSystems.jl
+++ b/src/MathematicalSystems.jl
@@ -56,8 +56,8 @@ export ContinuousIdentitySystem,
        ConstrainedBlackBoxControlContinuousSystem,
        NoisyConstrainedLinearContinuousSystem,
        NoisyConstrainedLinearControlContinuousSystem,
-       NoisyConstrainedBlackBoxControlContinuousSystem,
-       NoisyConstrainedAffineControlContinuousSystem
+       NoisyConstrainedAffineControlContinuousSystem,
+       NoisyConstrainedBlackBoxControlContinuousSystem
 
 #==================================
 Concrete Types for Discrete Systems

--- a/src/MathematicalSystems.jl
+++ b/src/MathematicalSystems.jl
@@ -53,11 +53,11 @@ export ContinuousIdentitySystem,
        ConstrainedPolynomialContinuousSystem,
        BlackBoxContinuousSystem,
        ConstrainedBlackBoxContinuousSystem,
-       ConstrainedBlackBoxControlContinuousSystem
+       ConstrainedBlackBoxControlContinuousSystem,
        NoisyConstrainedLinearContinuousSystem,
        NoisyConstrainedLinearControlContinuousSystem,
        NoisyConstrainedBlackBoxControlContinuousSystem,
-       NoisyConstrainedAffineControlContinuousSystem,
+       NoisyConstrainedAffineControlContinuousSystem
 
 #==================================
 Concrete Types for Discrete Systems

--- a/src/MathematicalSystems.jl
+++ b/src/MathematicalSystems.jl
@@ -48,6 +48,10 @@ export ContinuousIdentitySystem,
        BlackBoxContinuousSystem,
        ConstrainedBlackBoxContinuousSystem,
        ConstrainedBlackBoxControlContinuousSystem
+       NoisyConstrainedLinearContinuousSystem,
+       NoisyConstrainedLinearControlContinuousSystem,
+       NoisyConstrainedBlackBoxControlContinuousSystem,
+       NoisyConstrainedAffineControlContinuousSystem,
 
 #==================================
 Concrete Types for Discrete Systems
@@ -68,13 +72,9 @@ export DiscreteIdentitySystem,
        BlackBoxDiscreteSystem,
        ConstrainedBlackBoxDiscreteSystem,
        ConstrainedBlackBoxControlDiscreteSystem,
-       NoisyConstrainedLinearContinuousSystem,
        NoisyConstrainedLinearDiscreteSystem,
-       NoisyConstrainedLinearControlContinuousSystem,
        NoisyConstrainedLinearControlDiscreteSystem,
-       NoisyConstrainedAffineControlContinuousSystem,
        NoisyConstrainedAffineControlDiscreteSystem,
-       NoisyConstrainedBlackBoxControlContinuousSystem,
        NoisyConstrainedBlackBoxControlDiscreteSystem
 
 include("systems.jl")

--- a/src/MathematicalSystems.jl
+++ b/src/MathematicalSystems.jl
@@ -27,8 +27,7 @@ export statedim,
        inputdim,
        inputset,
        noisedim,
-       noiseset,
-
+       noiseset
 
 # traits
 export islinear,

--- a/src/MathematicalSystems.jl
+++ b/src/MathematicalSystems.jl
@@ -23,17 +23,19 @@ export AbstractSystem,
 
 # methods
 export statedim,
-       stateset,
        inputdim,
-       inputset,
        noisedim,
+       stateset,
+       inputset,
        noiseset
 
 # traits
 export islinear,
        isaffine,
        ispolynomial,
-       isnoisy
+       isnoisy,
+       iscontrolled,
+       isconstrained
 
 #====================================
 Concrete Types for Continuous Systems

--- a/src/systems.jl
+++ b/src/systems.jl
@@ -9,10 +9,13 @@ for (Z, AZ) in ((:ContinuousIdentitySystem, :AbstractContinuousSystem),
         end
         statedim(s::$Z) = s.statedim
         inputdim(s::$Z) = 0
+        noisedim(s::$Z) = 0
         islinear(::$Z) = true
         isaffine(::$Z) = true
         ispolynomial(::$Z) = false
         isnoisy(::$Z) = false
+        iscontrolled(::$Z) = false
+        isconstrained(::$Z) = false
     end
 end
 
@@ -53,12 +56,15 @@ for (Z, AZ) in ((:ConstrainedContinuousIdentitySystem, :AbstractContinuousSystem
             X::ST
         end
         statedim(s::$Z) = s.statedim
-        stateset(s::$Z) = s.X
         inputdim(::$Z) = 0
+        noisedim(::$Z) = 0
+        stateset(s::$Z) = s.X
         islinear(::$Z) = true
         isaffine(::$Z) = true
         ispolynomial(::$Z) = false
         isnoisy(::$Z) = false
+        iscontrolled(::$Z) = false
+        isconstrained(::$Z) = true
     end
 end
 
@@ -102,10 +108,13 @@ for (Z, AZ) in ((:LinearContinuousSystem, :AbstractContinuousSystem),
         end
         statedim(s::$Z) = checksquare(s.A)
         inputdim(::$Z) = 0
+        noisedim(::$Z) = 0
         islinear(::$Z) = true
         isaffine(::$Z) = true
         ispolynomial(::$Z) = false
         isnoisy(::$Z) = false
+        iscontrolled(::$Z) = false
+        isconstrained(::$Z) = false
     end
 end
 
@@ -152,10 +161,13 @@ for (Z, AZ) in ((:AffineContinuousSystem, :AbstractContinuousSystem),
         end
         statedim(s::$Z) = length(s.b)
         inputdim(::$Z) = 0
+        noisedim(::$Z) = 0
         islinear(::$Z) = false
         isaffine(::$Z) = true
         ispolynomial(::$Z) = false
         isnoisy(::$Z) = false
+        iscontrolled(::$Z) = false
+        isconstrained(::$Z) = false
     end
 end
 
@@ -204,10 +216,13 @@ for (Z, AZ) in ((:LinearControlContinuousSystem, :AbstractContinuousSystem),
         end
         statedim(s::$Z) = checksquare(s.A)
         inputdim(s::$Z) = size(s.B, 2)
+        noisedim(::$Z) = 0
         islinear(::$Z) = true
         isaffine(::$Z) = true
         ispolynomial(::$Z) = false
         isnoisy(::$Z) = false
+        iscontrolled(::$Z) = true
+        isconstrained(::$Z) = false
     end
 end
 
@@ -251,12 +266,15 @@ for (Z, AZ) in ((:ConstrainedLinearContinuousSystem, :AbstractContinuousSystem),
             X::ST
         end
         statedim(s::$Z) = checksquare(s.A)
-        stateset(s::$Z) = s.X
         inputdim(::$Z) = 0
+        noisedim(::$Z) = 0
+        stateset(s::$Z) = s.X
         islinear(::$Z) = true
         isaffine(::$Z) = true
         ispolynomial(::$Z) = false
         isnoisy(::$Z) = false
+        iscontrolled(::$Z) = false
+        isconstrained(::$Z) = true
     end
 end
 
@@ -305,12 +323,15 @@ for (Z, AZ) in ((:ConstrainedAffineContinuousSystem, :AbstractContinuousSystem),
             end
         end
         statedim(s::$Z) = length(s.b)
-        stateset(s::$Z) = s.X
         inputdim(::$Z) = 0
+        noisedim(::$Z) = 0
+        stateset(s::$Z) = s.X
         islinear(::$Z) = false
         isaffine(::$Z) = true
         ispolynomial(::$Z) = false
         isnoisy(::$Z) = false
+        iscontrolled(::$Z) = false
+        isconstrained(::$Z) = true
     end
 end
 
@@ -363,13 +384,16 @@ for (Z, AZ) in ((:ConstrainedAffineControlContinuousSystem, :AbstractContinuousS
             end
         end
         statedim(s::$Z) = length(s.c)
-        stateset(s::$Z) = s.X
         inputdim(s::$Z) = size(s.B, 2)
+        noisedim(::$Z) = 0
+        stateset(s::$Z) = s.X
         inputset(s::$Z) = s.U
         islinear(::$Z) = false
         isaffine(::$Z) = true
         ispolynomial(::$Z) = false
         isnoisy(::$Z) = false
+        iscontrolled(::$Z) = true
+        isconstrained(::$Z) = true
     end
 end
 
@@ -427,13 +451,16 @@ for (Z, AZ) in ((:ConstrainedLinearControlContinuousSystem, :AbstractContinuousS
             end
         end
         statedim(s::$Z) = checksquare(s.A)
-        stateset(s::$Z) = s.X
         inputdim(s::$Z) = size(s.B, 2)
+        noisedim(::$Z) = 0
+        stateset(s::$Z) = s.X
         inputset(s::$Z) = s.U
         islinear(::$Z) = true
         isaffine(::$Z) = true
         ispolynomial(::$Z) = false
         isnoisy(::$Z) = false
+        iscontrolled(::$Z) = true
+        isconstrained(::$Z) = true
     end
 end
 
@@ -485,10 +512,13 @@ for (Z, AZ) in ((:LinearAlgebraicContinuousSystem, :AbstractContinuousSystem),
         end
         statedim(s::$Z) = size(s.A, 1)
         inputdim(::$Z) = 0
+        noisedim(::$Z) = 0
         islinear(::$Z) = true
         isaffine(::$Z) = true
         ispolynomial(::$Z) = false
         isnoisy(::$Z) = false
+        iscontrolled(::$Z) = false
+        isconstrained(::$Z) = false
     end
 end
 
@@ -537,12 +567,15 @@ for (Z, AZ) in ((:ConstrainedLinearAlgebraicContinuousSystem, :AbstractContinuou
             end
         end
         statedim(s::$Z) = size(s.A, 1)
-        stateset(s::$Z) = s.X
         inputdim(::$Z) = 0
+        noisedim(::$Z) = 0
+        stateset(s::$Z) = s.X
         islinear(::$Z) = true
         isaffine(::$Z) = true
         ispolynomial(::$Z) = false
         isnoisy(::$Z) = false
+        iscontrolled(::$Z) = false
+        isconstrained(::$Z) = true
     end
 end
 
@@ -593,10 +626,13 @@ for (Z, AZ) in ((:PolynomialContinuousSystem, :AbstractContinuousSystem),
         end
         statedim(s::$Z) = s.statedim
         inputdim(::$Z) = 0
+        noisedim(::$Z) = 0
         islinear(::$Z) = false
         isaffine(::$Z) = false
         ispolynomial(::$Z) = true
         isnoisy(::$Z) = false
+        iscontrolled(::$Z) = false
+        isconstrained(::$Z) = false
 
         MultivariatePolynomials.variables(s::$Z) = MultivariatePolynomials.variables(s.p)
         MultivariatePolynomials.nvariables(s::$Z) = s.statedim
@@ -651,12 +687,15 @@ for (Z, AZ) in ((:ConstrainedPolynomialContinuousSystem, :AbstractContinuousSyst
             end
         end
         statedim(s::$Z) = s.statedim
-        stateset(s::$Z) = s.X
         inputdim(::$Z) = 0
+        noisedim(::$Z) = 0
+        stateset(s::$Z) = s.X
         islinear(::$Z) = false
         isaffine(::$Z) = false
         ispolynomial(::$Z) = true
         isnoisy(::$Z) = false
+        iscontrolled(::$Z) = false
+        isconstrained(::$Z) = true
 
         MultivariatePolynomials.variables(s::$Z) = MultivariatePolynomials.variables(s.p)
         MultivariatePolynomials.nvariables(s::$Z) = s.statedim
@@ -709,10 +748,13 @@ for (Z, AZ) in ((:BlackBoxContinuousSystem, :AbstractContinuousSystem),
         end
         statedim(s::$Z) = s.statedim
         inputdim(s::$Z) = 0
+        noisedim(::$Z) = 0
         islinear(::$Z) = false
         isaffine(::$Z) = false
         ispolynomial(::$Z) = false
         isnoisy(::$Z) = false
+        iscontrolled(::$Z) = false
+        isconstrained(::$Z) = false
     end
 end
 
@@ -757,12 +799,15 @@ for (Z, AZ) in ((:ConstrainedBlackBoxContinuousSystem, :AbstractContinuousSystem
             X::ST
         end
         statedim(s::$Z) = s.statedim
-        stateset(s::$Z) = s.X
         inputdim(s::$Z) = 0
+        noisedim(::$Z) = 0
+        stateset(s::$Z) = s.X
         islinear(::$Z) = false
         isaffine(::$Z) = false
         ispolynomial(::$Z) = false
         isnoisy(::$Z) = false
+        iscontrolled(::$Z) = false
+        isconstrained(::$Z) = true
     end
 end
 
@@ -813,13 +858,16 @@ for (Z, AZ) in ((:ConstrainedBlackBoxControlContinuousSystem, :AbstractContinuou
             U::UT
         end
         statedim(s::$Z) = s.statedim
-        stateset(s::$Z) = s.X
         inputdim(s::$Z) = s.inputdim
+        noisedim(::$Z) = 0
+        stateset(s::$Z) = s.X
         inputset(s::$Z) = s.U
         islinear(::$Z) = false
         isaffine(::$Z) = false
         ispolynomial(::$Z) = false
         isnoisy(::$Z) = false
+        iscontrolled(::$Z) = true
+        isconstrained(::$Z) = true
     end
 end
 
@@ -877,14 +925,16 @@ for (Z, AZ) in ((:NoisyConstrainedLinearContinuousSystem, :AbstractContinuousSys
             end
         end
         statedim(s::$Z) = size(s.A,1)
-        stateset(s::$Z) = s.X
-        noisedim(s::$Z) = size(s.D, 2)
-        noiseset(s::$Z) = s.W
         inputdim(::$Z) = 0
+        noisedim(s::$Z) = size(s.D, 2)
+        stateset(s::$Z) = s.X
+        noiseset(s::$Z) = s.W
         islinear(::$Z) = true
         isaffine(::$Z) = true
         ispolynomial(::$Z) = false
         isnoisy(::$Z) = true
+        iscontrolled(::$Z) = false
+        isconstrained(::$Z) = true
     end
 end
 
@@ -940,15 +990,17 @@ for (Z, AZ) in ((:NoisyConstrainedLinearControlContinuousSystem, :AbstractContin
             end
         end
         statedim(s::$Z) = size(s.A, 1)
-        stateset(s::$Z) = s.X
         inputdim(s::$Z) = size(s.B, 2)
-        inputset(s::$Z) = s.U
         noisedim(s::$Z) = size(s.D, 2)
+        stateset(s::$Z) = s.X
+        inputset(s::$Z) = s.U
         noiseset(s::$Z) = s.W
         islinear(::$Z) = true
         isaffine(::$Z) = true
         ispolynomial(::$Z) = false
         isnoisy(::$Z) = true
+        iscontrolled(::$Z) = true
+        isconstrained(::$Z) = true
     end
 end
 
@@ -1012,6 +1064,8 @@ for (Z, AZ) in ((:NoisyConstrainedAffineControlContinuousSystem, :AbstractContin
         isaffine(::$Z) = true
         ispolynomial(::$Z) = false
         isnoisy(::$Z) = true
+        iscontrolled(::$Z) = true
+        isconstrained(::$Z) = true
     end
 end
 
@@ -1065,15 +1119,17 @@ for (Z, AZ) in ((:NoisyConstrainedBlackBoxControlContinuousSystem, :AbstractCont
             W::WT
         end
         statedim(s::$Z) = s.statedim
-        stateset(s::$Z) = s.X
         inputdim(s::$Z) = s.inputdim
-        inputset(s::$Z) = s.U
         noisedim(s::$Z) = s.noisedim
+        stateset(s::$Z) = s.X
+        inputset(s::$Z) = s.U
         noiseset(s::$Z) = s.W
         islinear(::$Z) = false
         isaffine(::$Z) = false
         ispolynomial(::$Z) = false
         isnoisy(::$Z) = true
+        iscontrolled(::$Z) = true
+        isconstrained(::$Z) = true
     end
 end
 

--- a/src/systems.jl
+++ b/src/systems.jl
@@ -844,7 +844,6 @@ of the form:
 """
 ConstrainedBlackBoxControlDiscreteSystem
 
-# Noisy Systems
 for (Z, AZ) in ((:NoisyConstrainedLinearContinuousSystem, :AbstractContinuousSystem),
                 (:NoisyConstrainedLinearDiscreteSystem, :AbstractDiscreteSystem))
     @eval begin
@@ -854,17 +853,11 @@ for (Z, AZ) in ((:NoisyConstrainedLinearContinuousSystem, :AbstractContinuousSys
             X::ST
             W::WT
             function $(Z)(A::MTA, D::MTD, X::ST, W::WT) where {T, MTA <: AbstractMatrix{T}, MTD <: AbstractMatrix{T}, ST, WT}
-                @assert checksquare(A) == size(D,1) # == dim(X)
+                @assert checksquare(A) == size(D,1)
                 return new{T, MTA, MTD, ST, WT}(A, D, X, W)
             end
-            function $(Z)(A::MTA, X::ST, W::WT) where {T, MTA <: AbstractMatrix{T}, ST, WT}
-                # @assert checksquare(A) == dim(X)
-                n = size(A,1)
-                D = Matrix{T}(I, n, n)
-                return new{T, MTA, MTA, ST, WT}(A, D, X, W)
-            end
         end
-        statedim(s::$Z) = checksquare(s.A)
+        statedim(s::$Z) = size(s.A,1)
         stateset(s::$Z) = s.X
         noisedim(s::$Z) = size(s.D, 2)
         noiseset(s::$Z) = s.W
@@ -924,12 +917,6 @@ for (Z, AZ) in ((:NoisyConstrainedLinearControlContinuousSystem, :AbstractContin
             function $(Z)(A::MTA, B::MTB, D::MTD, X::ST, U::UT, W::WT) where {T, MTA <: AbstractMatrix{T}, MTB <: AbstractMatrix{T}, MTD <: AbstractMatrix{T}, ST, UT, WT}
                 @assert checksquare(A) == size(B, 1) == size(D,1)
                 return new{T, MTA, MTB, MTD, ST, UT, WT}(A, B, D, X, U, W)
-            end
-            function $(Z)(A::MTA, B::MTB, X::ST, U::UT, W::WT) where {T, MTA <: AbstractMatrix{T}, MTB <: AbstractMatrix{T}, ST, UT, WT}
-                @assert checksquare(A) == size(B, 1) # == dim(W)
-                n = size(A,1)
-                D = Matrix{T}(I, n, n)
-                return new{T, MTA, MTB, MTA, ST, UT, WT}(A, B, D, X, U, W)
             end
         end
         statedim(s::$Z) = size(s.A, 1)
@@ -993,12 +980,6 @@ for (Z, AZ) in ((:NoisyConstrainedAffineControlContinuousSystem, :AbstractContin
                 @assert checksquare(A) == length(c) == size(B, 1) == size(D,1)
                 return new{T, MTA, MTB, VT, MTD, ST, UT, WT}(A, B, c, D, X, U, W)
             end
-            function $(Z)(A::MTA, B::MTB, c::VT, X::ST, U::UT, W::WT) where {T, MTA <: AbstractMatrix{T}, MTB <: AbstractMatrix{T}, VT <: AbstractVector{T}, ST, UT, WT}
-                @assert checksquare(A) == length(c) == size(B, 1) # ==  dim(W)
-                n = size(A,1)
-                D = Matrix{T}(I, n, n)
-                return new{T, MTA, MTB, VT, MTA, ST, UT, WT}(A, B, c, D, X, U, W)
-            end
         end
         statedim(s::$Z) = length(s.c)
         stateset(s::$Z) = s.X
@@ -1061,10 +1042,6 @@ for (Z, AZ) in ((:NoisyConstrainedBlackBoxControlContinuousSystem, :AbstractCont
             U::UT
             W::WT
         end
-        # function $(Z)(f::FT, X::ST, U::UT, W::WT) where {FT, ST, UT, WT}
-        #     # @assert  length(f(zeros(dim(X)), zeros(dim(U)))) == dim(X)
-        #     return new{FT, ST, UT, WT}(f, dim(X), dim(U), X, U, W)
-        # end
         statedim(s::$Z) = s.statedim
         stateset(s::$Z) = s.X
         inputdim(s::$Z) = s.inputdim

--- a/src/systems.jl
+++ b/src/systems.jl
@@ -12,6 +12,7 @@ for (Z, AZ) in ((:ContinuousIdentitySystem, :AbstractContinuousSystem),
         islinear(::$Z) = true
         isaffine(::$Z) = true
         ispolynomial(::$Z) = false
+        isnoisy(::$Z) = false
     end
 end
 
@@ -57,6 +58,7 @@ for (Z, AZ) in ((:ConstrainedContinuousIdentitySystem, :AbstractContinuousSystem
         islinear(::$Z) = true
         isaffine(::$Z) = true
         ispolynomial(::$Z) = false
+        isnoisy(::$Z) = false
     end
 end
 
@@ -103,6 +105,7 @@ for (Z, AZ) in ((:LinearContinuousSystem, :AbstractContinuousSystem),
         islinear(::$Z) = true
         isaffine(::$Z) = true
         ispolynomial(::$Z) = false
+        isnoisy(::$Z) = false
     end
 end
 
@@ -152,6 +155,7 @@ for (Z, AZ) in ((:AffineContinuousSystem, :AbstractContinuousSystem),
         islinear(::$Z) = false
         isaffine(::$Z) = true
         ispolynomial(::$Z) = false
+        isnoisy(::$Z) = false
     end
 end
 
@@ -203,6 +207,7 @@ for (Z, AZ) in ((:LinearControlContinuousSystem, :AbstractContinuousSystem),
         islinear(::$Z) = true
         isaffine(::$Z) = true
         ispolynomial(::$Z) = false
+        isnoisy(::$Z) = false
     end
 end
 
@@ -251,6 +256,7 @@ for (Z, AZ) in ((:ConstrainedLinearContinuousSystem, :AbstractContinuousSystem),
         islinear(::$Z) = true
         isaffine(::$Z) = true
         ispolynomial(::$Z) = false
+        isnoisy(::$Z) = false
     end
 end
 
@@ -304,6 +310,7 @@ for (Z, AZ) in ((:ConstrainedAffineContinuousSystem, :AbstractContinuousSystem),
         islinear(::$Z) = false
         isaffine(::$Z) = true
         ispolynomial(::$Z) = false
+        isnoisy(::$Z) = false
     end
 end
 
@@ -362,6 +369,7 @@ for (Z, AZ) in ((:ConstrainedAffineControlContinuousSystem, :AbstractContinuousS
         islinear(::$Z) = false
         isaffine(::$Z) = true
         ispolynomial(::$Z) = false
+        isnoisy(::$Z) = false
     end
 end
 
@@ -425,6 +433,7 @@ for (Z, AZ) in ((:ConstrainedLinearControlContinuousSystem, :AbstractContinuousS
         islinear(::$Z) = true
         isaffine(::$Z) = true
         ispolynomial(::$Z) = false
+        isnoisy(::$Z) = false
     end
 end
 
@@ -479,6 +488,7 @@ for (Z, AZ) in ((:LinearAlgebraicContinuousSystem, :AbstractContinuousSystem),
         islinear(::$Z) = true
         isaffine(::$Z) = true
         ispolynomial(::$Z) = false
+        isnoisy(::$Z) = false
     end
 end
 
@@ -532,6 +542,7 @@ for (Z, AZ) in ((:ConstrainedLinearAlgebraicContinuousSystem, :AbstractContinuou
         islinear(::$Z) = true
         isaffine(::$Z) = true
         ispolynomial(::$Z) = false
+        isnoisy(::$Z) = false
     end
 end
 
@@ -585,6 +596,7 @@ for (Z, AZ) in ((:PolynomialContinuousSystem, :AbstractContinuousSystem),
         islinear(::$Z) = false
         isaffine(::$Z) = false
         ispolynomial(::$Z) = true
+        isnoisy(::$Z) = false
 
         MultivariatePolynomials.variables(s::$Z) = MultivariatePolynomials.variables(s.p)
         MultivariatePolynomials.nvariables(s::$Z) = s.statedim
@@ -644,6 +656,7 @@ for (Z, AZ) in ((:ConstrainedPolynomialContinuousSystem, :AbstractContinuousSyst
         islinear(::$Z) = false
         isaffine(::$Z) = false
         ispolynomial(::$Z) = true
+        isnoisy(::$Z) = false
 
         MultivariatePolynomials.variables(s::$Z) = MultivariatePolynomials.variables(s.p)
         MultivariatePolynomials.nvariables(s::$Z) = s.statedim
@@ -698,6 +711,8 @@ for (Z, AZ) in ((:BlackBoxContinuousSystem, :AbstractContinuousSystem),
         inputdim(s::$Z) = 0
         islinear(::$Z) = false
         isaffine(::$Z) = false
+        ispolynomial(::$Z) = false
+        isnoisy(::$Z) = false
     end
 end
 
@@ -746,6 +761,8 @@ for (Z, AZ) in ((:ConstrainedBlackBoxContinuousSystem, :AbstractContinuousSystem
         inputdim(s::$Z) = 0
         islinear(::$Z) = false
         isaffine(::$Z) = false
+        ispolynomial(::$Z) = false
+        isnoisy(::$Z) = false
     end
 end
 
@@ -801,6 +818,8 @@ for (Z, AZ) in ((:ConstrainedBlackBoxControlContinuousSystem, :AbstractContinuou
         inputset(s::$Z) = s.U
         islinear(::$Z) = false
         isaffine(::$Z) = false
+        ispolynomial(::$Z) = false
+        isnoisy(::$Z) = false
     end
 end
 
@@ -864,6 +883,7 @@ for (Z, AZ) in ((:NoisyConstrainedLinearContinuousSystem, :AbstractContinuousSys
         inputdim(::$Z) = 0
         islinear(::$Z) = true
         isaffine(::$Z) = true
+        ispolynomial(::$Z) = false
         isnoisy(::$Z) = true
     end
 end
@@ -927,6 +947,7 @@ for (Z, AZ) in ((:NoisyConstrainedLinearControlContinuousSystem, :AbstractContin
         noiseset(s::$Z) = s.W
         islinear(::$Z) = true
         isaffine(::$Z) = true
+        ispolynomial(::$Z) = false
         isnoisy(::$Z) = true
     end
 end
@@ -989,6 +1010,7 @@ for (Z, AZ) in ((:NoisyConstrainedAffineControlContinuousSystem, :AbstractContin
         noiseset(s::$Z) = s.W
         islinear(::$Z) = false
         isaffine(::$Z) = true
+        ispolynomial(::$Z) = false
         isnoisy(::$Z) = true
     end
 end
@@ -1050,6 +1072,7 @@ for (Z, AZ) in ((:NoisyConstrainedBlackBoxControlContinuousSystem, :AbstractCont
         noiseset(s::$Z) = s.W
         islinear(::$Z) = false
         isaffine(::$Z) = false
+        ispolynomial(::$Z) = false
         isnoisy(::$Z) = true
     end
 end

--- a/test/continuous.jl
+++ b/test/continuous.jl
@@ -233,9 +233,6 @@ end
     @test noiseset(s) == W
     @test inputdim(s) == 0
     @test islinear(s) && isaffine(s) && isnoisy(s)
-    # if D is omitted, add the identiy matrix
-    s2 = NoisyConstrainedLinearContinuousSystem(A, X, W)
-    @test s2.D == [1. 0; 0 1]
 end
 
 @testset "Noisy Continuous constrained control linear system" begin
@@ -255,9 +252,6 @@ end
     @test noiseset(s) == W
     @test inputdim(s) == dim(U)
     @test islinear(s) && isaffine(s) && isnoisy(s)
-    # if D is omitted, add the identiy matrix
-    s2 = NoisyConstrainedLinearControlContinuousSystem(A, B, X, U, W)
-    @test s2.D == [1. 0; 0 1]
 end
 
 @testset "Noisy Continuous constrained control affine system" begin
@@ -279,9 +273,6 @@ end
     @test noiseset(s) == W
     @test inputdim(s) == dim(U)
     @test isaffine(s) && isnoisy(s)
-    # if D is omitted, add the identiy matrix
-    s2 = NoisyConstrainedAffineControlContinuousSystem(A, B, c, X, U, W)
-    @test s2.D == [1. 0; 0 1]
 end
 
 @testset "Noisy Continuous constrained control blackbox system" begin
@@ -300,5 +291,4 @@ end
     @test noiseset(s) == W
     @test inputdim(s) == dim(U)
     @test !islinear(s) && !isaffine(s) && isnoisy(s)
-    # s = NoisyConstrainedBlackBoxControlContinuousSystem(f, X, U, W)
 end

--- a/test/continuous.jl
+++ b/test/continuous.jl
@@ -95,17 +95,6 @@ end
     @test !isnoisy(s) && iscontrolled(s) && isconstrained(s)
 end
 
-@testset "Continuous constrained affine system" begin
-    X = Line([1., -1], 0.) # line x = y
-    s = ConstrainedAffineContinuousSystem(zeros(2, 2), zeros(2), X)
-    @test statedim(s) == 2
-    @test inputdim(s) == 0
-    @test noisedim(s) == 0
-    @test stateset(s) == X
-    @test !islinear(s) && isaffine(s) && !ispolynomial(s)
-    @test !isnoisy(s) && !iscontrolled(s) && isconstrained(s)
-end
-
 @testset "Continuous constrained linear control system" begin
     A = [1. 1; 1 -1]
     B = Matrix([0.5 1.5]')

--- a/test/continuous.jl
+++ b/test/continuous.jl
@@ -327,7 +327,7 @@ end
     @test stateset(s) == X
     @test inputset(s) == U
     @test noiseset(s) == W
-    @test isaffine(s) && isnoisy(s) && !ispolynomial(s)
+    @test isaffine(s) && !islinear(s) && !ispolynomial(s)
     @test isnoisy(s) && iscontrolled(s) && isconstrained(s)
 end
 

--- a/test/continuous.jl
+++ b/test/continuous.jl
@@ -3,7 +3,7 @@
         s = ContinuousIdentitySystem(sd)
         @test statedim(s) == sd
         @test inputdim(s) == 0
-        @test islinear(s) && isaffine(s) && !ispolynomial(s)
+        @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isnoisy(s)
     end
 end
 
@@ -14,7 +14,7 @@ end
         @test statedim(s) == sd
         @test stateset(s) == X
         @test inputdim(s) == 0
-        @test islinear(s) && isaffine(s) && !ispolynomial(s)
+        @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isnoisy(s)
     end
 end
 
@@ -23,7 +23,7 @@ end
         s = LinearContinuousSystem(zeros(sd, sd))
         @test statedim(s) == sd
         @test inputdim(s) == 0
-        @test islinear(s) && isaffine(s) && !ispolynomial(s)
+        @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isnoisy(s)
     end
 end
 
@@ -32,7 +32,7 @@ end
         s = AffineContinuousSystem(zeros(sd, sd), zeros(sd))
         @test statedim(s) == sd
         @test inputdim(s) == 0
-        @test !islinear(s) && isaffine(s) && !ispolynomial(s)
+        @test !islinear(s) && isaffine(s) && !ispolynomial(s) && !isnoisy(s)
     end
 end
 
@@ -47,7 +47,7 @@ end
     @test stateset(s) == X
     @test inputdim(s) == 1
     @test inputset(s) == U
-    @test !islinear(s) && isaffine(s) && !ispolynomial(s)
+    @test !islinear(s) && isaffine(s) && !ispolynomial(s) && !isnoisy(s)
 end
 
 @testset "Continuous linear control system" begin
@@ -55,7 +55,7 @@ end
         s = LinearControlContinuousSystem(zeros(sd, sd), ones(sd, sd))
         @test statedim(s) == sd
         @test inputdim(s) == sd
-        @test islinear(s) && isaffine(s) && !ispolynomial(s)
+        @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isnoisy(s)
     end
 end
 
@@ -66,7 +66,7 @@ end
     @test statedim(s) == 2
     @test stateset(s) == X
     @test inputdim(s) == 0
-    @test islinear(s) && isaffine(s) && !ispolynomial(s)
+    @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isnoisy(s)
 end
 
 @testset "Continuous constrained affine system" begin
@@ -75,7 +75,7 @@ end
     @test statedim(s) == 2
     @test stateset(s) == X
     @test inputdim(s) == 0
-    @test !islinear(s) && isaffine(s) && !ispolynomial(s)
+    @test !islinear(s) && isaffine(s) && !ispolynomial(s) && !isnoisy(s)
 end
 
 @testset "Continuous constrained linear control system" begin
@@ -88,7 +88,7 @@ end
     @test stateset(s) == X
     @test inputdim(s) == 1
     @test inputset(s) == U
-    @test islinear(s) && isaffine(s) && !ispolynomial(s)
+    @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isnoisy(s)
 
     # initial value problem composite type
     x0 = Singleton([1.5, 2.0])
@@ -111,7 +111,7 @@ end
 @testset "Continuous linear algebraic system" begin
     for sd in 1:3
         s = LinearAlgebraicContinuousSystem(zeros(sd, sd), zeros(sd, sd))
-        @test islinear(s) && isaffine(s) && !ispolynomial(s)
+        @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isnoisy(s)
         @test statedim(s) == sd
         @test inputdim(s) == 0
     end
@@ -122,7 +122,7 @@ end
     E = [0. 1; 1 0]
     X = LinearConstraint([0, -1.], 0.) # the set y ≥ 0
     s = ConstrainedLinearAlgebraicContinuousSystem(A, E, X)
-    @test islinear(s) && isaffine(s) && !ispolynomial(s)
+    @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isnoisy(s)
     @test statedim(s) == 2
     @test stateset(s) == X
     @test inputdim(s) == 0
@@ -133,7 +133,7 @@ end
     E = [0. 1; 1 0]
     X = LinearConstraint([0, -1.], 0.) # the set y ≥ 0
     s = ConstrainedLinearAlgebraicContinuousSystem(A, E, X)
-    @test islinear(s) && isaffine(s) && !ispolynomial(s)
+    @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isnoisy(s)
     x0 = Singleton([1.5, 2.0])
     p = IVP(s, x0)
     @test statedim(p) == 2
@@ -146,7 +146,7 @@ end
 
     # default constructor for scalar p and
     s = PolynomialContinuousSystem(p)
-    @test !islinear(s) && !isaffine(s) && ispolynomial(s)
+    @test !islinear(s) && !isaffine(s) && ispolynomial(s) && !isnoisy(s)
     @test statedim(s) == 2
     @test inputdim(s) == 0
     @test TypedPolynomials.nvariables(s) == 2
@@ -163,7 +163,7 @@ end
 
     # default constructor for scalar p and
     s = ConstrainedPolynomialContinuousSystem(p, X)
-    @test !islinear(s) && !isaffine(s) && ispolynomial(s)
+    @test !islinear(s) && !isaffine(s) && ispolynomial(s) && !isnoisy(s)
     @test statedim(s) == 2
     @test inputdim(s) == 0
     @test dim(stateset(s)) == dim(X)
@@ -184,6 +184,7 @@ end
     dx = similar(x)
     f!(x, dx)
     @test dx ≈ [0.0, -1.0]
+    @test !islinear(s) && !isaffine(s) && !ispolynomial(s) && !isnoisy(s)
 end
 
 @testset "Continuous system defined by a function with state constraints" begin
@@ -195,6 +196,7 @@ end
     f!(x, dx)
     @test dx ≈ [0.0, -1.0]
     @test stateset(s) == H
+    @test !islinear(s) && !isaffine(s) && !ispolynomial(s) && !isnoisy(s)
 end
 
 function vanderpol_controlled!(x, u, dx)
@@ -216,6 +218,7 @@ end
     @test stateset(s) == H
     @test inputdim(s) == 1
     @test inputset(s) == U
+    @test !islinear(s) && !isaffine(s) && !ispolynomial(s) && !isnoisy(s)
 end
 
 # Noisy
@@ -232,7 +235,7 @@ end
     @test noisedim(s) == 2 == dim(W)
     @test noiseset(s) == W
     @test inputdim(s) == 0
-    @test islinear(s) && isaffine(s) && isnoisy(s)
+    @test islinear(s) && isaffine(s) && !ispolynomial(s) && isnoisy(s)
 end
 
 @testset "Noisy Continuous constrained control linear system" begin
@@ -251,7 +254,7 @@ end
     @test noisedim(s) == 2 == dim(W)
     @test noiseset(s) == W
     @test inputdim(s) == dim(U)
-    @test islinear(s) && isaffine(s) && isnoisy(s)
+    @test islinear(s) && isaffine(s)  && !ispolynomial(s) && isnoisy(s)
 end
 
 @testset "Noisy Continuous constrained control affine system" begin
@@ -272,7 +275,7 @@ end
     @test noisedim(s) == 2 == dim(W)
     @test noiseset(s) == W
     @test inputdim(s) == dim(U)
-    @test isaffine(s) && isnoisy(s)
+    @test !islinear(s) && isaffine(s)  && !ispolynomial(s) && isnoisy(s)
 end
 
 @testset "Noisy Continuous constrained control blackbox system" begin
@@ -290,5 +293,5 @@ end
     @test noisedim(s) == l == dim(W)
     @test noiseset(s) == W
     @test inputdim(s) == dim(U)
-    @test !islinear(s) && !isaffine(s) && isnoisy(s)
+    @test !islinear(s) && !isaffine(s)  && !ispolynomial(s) && isnoisy(s)
 end

--- a/test/discrete.jl
+++ b/test/discrete.jl
@@ -134,3 +134,89 @@ end
     x = 1.0
     @test s.f(x) ≈ 2.0
 end
+
+
+# Noisy
+@testset "Noisy Discrete constrained linear system" begin
+    A = [1. 1; 1 -1]
+    D = [1. 2; 0 1]
+    X = Line([1., -1], 0.) # line x = y
+    W = BallInf(zeros(2), 2.0)
+    s = NoisyConstrainedLinearDiscreteSystem(A, D, X, W)
+    @test statedim(s) == 2
+    @test stateset(s) == X
+    @test s.A == A
+    @test s.D == D
+    @test noisedim(s) == 2 == dim(W)
+    @test noiseset(s) == W
+    @test inputdim(s) == 0
+    @test islinear(s) && isaffine(s) && isnoisy(s)
+    # if D is omitted, add the identiy matrix
+    s2 = NoisyConstrainedLinearDiscreteSystem(A, X, W)
+    @test s2.D == [1. 0; 0 1]
+end
+
+@testset "Noisy Discrete constrained control linear system" begin
+    A = [1. 1; 1 -1]
+    B = Matrix([0.5 1.5]')
+    D = [1. 2; 0 1]
+    X = Line([1., -1], 0.) # line x = y
+    U = Hyperrectangle(low=[0.9], high=[1.1])
+    W = BallInf(zeros(2), 2.0)
+    s = NoisyConstrainedLinearControlDiscreteSystem(A, B, D, X, U, W)
+    @test statedim(s) == 2
+    @test stateset(s) == X
+    @test s.A == A
+    @test s.B == B
+    @test s.D == D
+    @test noisedim(s) == 2 == dim(W)
+    @test noiseset(s) == W
+    @test inputdim(s) == dim(U)
+    @test islinear(s) && isaffine(s) && isnoisy(s)
+    # if D is omitted, add the identiy matrix
+    s2 = NoisyConstrainedLinearControlDiscreteSystem(A, B, X, U, W)
+    @test s2.D == [1. 0; 0 1]
+end
+
+@testset "Noisy Discrete constrained control affine system" begin
+    A = [1. 1; 1 -1]
+    B = Matrix([0.5 1.5]')
+    c = [1.0, 0.5]
+    D = [1. 2; 0 1]
+    X = Line([1., -1], 0.) # line x = y
+    U = Hyperrectangle(low=[0.9], high=[1.1])
+    W = BallInf(zeros(2), 2.0)
+    s = NoisyConstrainedAffineControlDiscreteSystem(A, B, c, D, X, U, W)
+    @test statedim(s) == 2
+    @test stateset(s) == X
+    @test s.A == A
+    @test s.B == B
+    @test s.c == c
+    @test s.D == D
+    @test noisedim(s) == 2 == dim(W)
+    @test noiseset(s) == W
+    @test inputdim(s) == dim(U)
+    @test isaffine(s) && isnoisy(s)
+    # if D is omitted, add the identiy matrix
+    s2 = NoisyConstrainedAffineControlDiscreteSystem(A, B, c, X, U, W)
+    @test s2.D == [1. 0; 0 1]
+end
+
+@testset "Noisy Discrete constrained control blackbox system" begin
+    n = 2
+    m = 1
+    l = 2
+    f(x,u,w) = ones(n,n)*x + ones(n,m)*u + ones(n,l)*w
+    X = BallInf(zeros(n), 1.0)
+    U =  BallInf(zeros(m), 1.0)
+    W =  BallInf(zeros(l), 1.0)
+    s = NoisyConstrainedBlackBoxControlDiscreteSystem(f, n, m, l, X, U, W)
+    @test statedim(s) == n
+    @test s.f == f
+    @test stateset(s) == X
+    @test noisedim(s) == l == dim(W)
+    @test noiseset(s) == W
+    @test inputdim(s) == dim(U)
+    @test !islinear(s) && !isaffine(s) && isnoisy(s)
+    # s = NoisyConstrainedBlackBoxControlDiscreteSystem(f, X, U, W)
+end

--- a/test/discrete.jl
+++ b/test/discrete.jl
@@ -3,7 +3,9 @@
         s = DiscreteIdentitySystem(sd)
         @test statedim(s) == sd
         @test inputdim(s) == 0
+        @test noisedim(s) == 0
         @test islinear(s) && isaffine(s) && !ispolynomial(s)
+        @test !isnoisy(s) && !iscontrolled(s) && !isconstrained(s)
     end
 end
 
@@ -12,9 +14,11 @@ end
         X = Singleton(ones(sd))
         s = ConstrainedDiscreteIdentitySystem(sd, X)
         @test statedim(s) == sd
-        @test stateset(s) == X
         @test inputdim(s) == 0
+        @test noisedim(s) == 0
+        @test stateset(s) == X
         @test islinear(s) && isaffine(s) && !ispolynomial(s)
+        @test !isnoisy(s) && !iscontrolled(s) && isconstrained(s)
     end
 end
 
@@ -23,7 +27,20 @@ end
         s = LinearDiscreteSystem(zeros(sd, sd))
         @test statedim(s) == sd
         @test inputdim(s) == 0
+        @test noisedim(s) == 0
         @test islinear(s) && isaffine(s) && !ispolynomial(s)
+        @test !isnoisy(s) && !iscontrolled(s) && !isconstrained(s)
+    end
+end
+
+@testset "Discrete affine system" begin
+    for sd in 1:3
+        s = AffineDiscreteSystem(zeros(sd, sd), zeros(sd))
+        @test statedim(s) == sd
+        @test inputdim(s) == 0
+        @test noisedim(s) == 0
+        @test !islinear(s) && isaffine(s) && !ispolynomial(s)
+        @test !isnoisy(s) && !iscontrolled(s) && !isconstrained(s)
     end
 end
 
@@ -32,7 +49,9 @@ end
         s = LinearControlDiscreteSystem(zeros(sd, sd), ones(sd, sd))
         @test statedim(s) == sd
         @test inputdim(s) == sd
+        @test noisedim(s) == 0
         @test islinear(s) && isaffine(s) && !ispolynomial(s)
+        @test !isnoisy(s) && iscontrolled(s) && !isconstrained(s)
     end
 end
 
@@ -41,9 +60,24 @@ end
     X = Line([1., -1], 0.) # line x = y
     s = ConstrainedLinearDiscreteSystem(A, X)
     @test statedim(s) == 2
-    @test stateset(s) == X
     @test inputdim(s) == 0
+    @test noisedim(s) == 0
+    @test stateset(s) == X
     @test islinear(s) && isaffine(s) && !ispolynomial(s)
+    @test !isnoisy(s) && !iscontrolled(s) && isconstrained(s)
+end
+
+@testset "Discrete constrained affine system" begin
+    A = [1. 1; 1 -1]
+    c = [1.; 1.]
+    X = Line([1., -1], 0.) # line x = y
+    s = ConstrainedAffineDiscreteSystem(A, c, X)
+    @test statedim(s) == 2
+    @test inputdim(s) == 0
+    @test noisedim(s) == 0
+    @test stateset(s) == X
+    @test !islinear(s) && isaffine(s) && !ispolynomial(s)
+    @test !isnoisy(s) && !iscontrolled(s) && isconstrained(s)
 end
 
 @testset "Discrete constrained linear control system" begin
@@ -53,10 +87,12 @@ end
     U = Interval(0.9, 1.1)
     s = ConstrainedLinearControlDiscreteSystem(A, B, X, U)
     @test statedim(s) == 2
-    @test stateset(s) == X
     @test inputdim(s) == 1
+    @test noisedim(s) == 0
+    @test stateset(s) == X
     @test inputset(s) == U
     @test islinear(s) && isaffine(s) && !ispolynomial(s)
+    @test !isnoisy(s) && iscontrolled(s) && isconstrained(s)
 end
 
 @testset "Discrete linear algebraic system" begin
@@ -64,7 +100,9 @@ end
         s = LinearAlgebraicDiscreteSystem(zeros(sd, sd), zeros(sd, sd))
         @test statedim(s) == sd
         @test inputdim(s) == 0
+        @test noisedim(s) == 0
         @test islinear(s) && isaffine(s) && !ispolynomial(s)
+        @test !isnoisy(s) && !iscontrolled(s) && !isconstrained(s)
     end
 end
 
@@ -74,10 +112,127 @@ end
     X = LinearConstraint([0, -1.], 0.) # the set y ≥ 0
     s = ConstrainedLinearAlgebraicDiscreteSystem(A, E, X)
     @test statedim(s) == 2
-    @test stateset(s) == X
     @test inputdim(s) == 0
+    @test noisedim(s) == 0
+    @test stateset(s) == X
     @test islinear(s) && isaffine(s) && !ispolynomial(s)
+    @test !isnoisy(s) && !iscontrolled(s) && isconstrained(s)
 end
+
+@testset "Polynomial system in discrete time" begin
+    @polyvar x y
+    p = 2x^2 - 3x + y
+    s = PolynomialDiscreteSystem(p)
+    @test statedim(s) == 2
+    @test inputdim(s) == 0
+    @test noisedim(s) == 0
+    @test !islinear(s) && !isaffine(s) && ispolynomial(s)
+    @test !isnoisy(s) && !iscontrolled(s) && !isconstrained(s)
+end
+
+@testset "Polynomial system in discrete time with state constraints" begin
+    @polyvar x y
+    p = 2x^2 - 3x + y
+    X = BallInf(zeros(2), 0.1)
+    s = ConstrainedPolynomialDiscreteSystem(p, X)
+    @test statedim(s) == 2
+    @test inputdim(s) == 0
+    @test noisedim(s) == 0
+    @test dim(stateset(s)) == dim(X)
+    @test !islinear(s) && !isaffine(s) && ispolynomial(s)
+    @test !isnoisy(s) && !iscontrolled(s) && isconstrained(s)
+end
+
+@testset "Implicit discrete system" begin
+    add_one(x) = x + 1
+    s = BlackBoxDiscreteSystem(add_one, 1)
+    x = 1.0
+    @test s.f(x) ≈ 2.0
+    @test !islinear(s) && !isaffine(s) && !ispolynomial(s)
+    @test !isnoisy(s) && !iscontrolled(s) && !isconstrained(s)
+end
+
+@testset "Noisy Discrete constrained linear system" begin
+    A = [1. 1; 1 -1]
+    D = [1. 2; 0 1]
+    X = Line([1., -1], 0.) # line x = y
+    W = BallInf(zeros(2), 2.0)
+    s = NoisyConstrainedLinearDiscreteSystem(A, D, X, W)
+    @test s.A == A
+    @test s.D == D
+    @test statedim(s) == 2
+    @test inputdim(s) == 0
+    @test noisedim(s) == 2 == dim(W)
+    @test stateset(s) == X
+    @test noiseset(s) == W
+    @test islinear(s) && isaffine(s) && !ispolynomial(s)
+    @test isnoisy(s) && !iscontrolled(s) && isconstrained(s)
+end
+
+@testset "Noisy Discrete constrained control linear system" begin
+    A = [1. 1; 1 -1]
+    B = Matrix([0.5 1.5]')
+    D = [1. 2; 0 1]
+    X = Line([1., -1], 0.) # line x = y
+    U = Hyperrectangle(low=[0.9], high=[1.1])
+    W = BallInf(zeros(2), 2.0)
+    s = NoisyConstrainedLinearControlDiscreteSystem(A, B, D, X, U, W)
+    @test s.A == A
+    @test s.B == B
+    @test s.D == D
+    @test statedim(s) == 2
+    @test inputdim(s) == dim(U)
+    @test noisedim(s) == 2 == dim(W)
+    @test stateset(s) == X
+    @test inputset(s) == U
+    @test noiseset(s) == W
+    @test islinear(s) && isaffine(s) && !ispolynomial(s)
+    @test isnoisy(s) && iscontrolled(s) && isconstrained(s)
+end
+
+@testset "Noisy Discrete constrained control affine system" begin
+    A = [1. 1; 1 -1]
+    B = Matrix([0.5 1.5]')
+    c = [1.0, 0.5]
+    D = [1. 2; 0 1]
+    X = Line([1., -1], 0.) # line x = y
+    U = Hyperrectangle(low=[0.9], high=[1.1])
+    W = BallInf(zeros(2), 2.0)
+    s = NoisyConstrainedAffineControlDiscreteSystem(A, B, c, D, X, U, W)
+    @test s.A == A
+    @test s.B == B
+    @test s.c == c
+    @test s.D == D
+    @test statedim(s) == 2
+    @test inputdim(s) == dim(U)
+    @test noisedim(s) == 2 == dim(W)
+    @test stateset(s) == X
+    @test inputset(s) == U
+    @test noiseset(s) == W
+    @test isaffine(s) && isnoisy(s) && !ispolynomial(s)
+    @test isnoisy(s) && iscontrolled(s) && isconstrained(s)
+end
+
+@testset "Noisy Discrete constrained control blackbox system" begin
+    n = 2
+    m = 1
+    l = 2
+    f(x,u,w) = ones(n,n)*x + ones(n,m)*u + ones(n,l)*w
+    X = BallInf(zeros(n), 1.0)
+    U =  BallInf(zeros(m), 1.0)
+    W =  BallInf(zeros(l), 1.0)
+    s = NoisyConstrainedBlackBoxControlDiscreteSystem(f, n, m, l, X, U, W)
+    @test s.f == f
+    @test statedim(s) == n
+    @test inputdim(s) == dim(U)
+    @test noisedim(s) == l == dim(W)
+    @test stateset(s) == X
+    @test inputset(s) == U
+    @test noiseset(s) == W
+    @test !islinear(s) && !isaffine(s) && !ispolynomial(s)
+    @test isnoisy(s) && iscontrolled(s) && isconstrained(s)
+end
+
 
 @testset "Constant input in a discrete constrained linear control system" begin
     A = [1. 1; 1 -1]
@@ -86,13 +241,13 @@ end
     U = ConstantInput(Hyperrectangle(low=[0.9], high=[1.1]))
     s = ConstrainedLinearControlDiscreteSystem(A, B, X, U)
     s = ConstrainedLinearControlDiscreteSystem(A, B, X, U)
-    @test islinear(s) && isaffine(s) && !ispolynomial(s)
     if VERSION < v"0.7-"
         @test next(s.U, 1)[1] isa Hyperrectangle
     else
         @test iterate(s.U)[1] isa Hyperrectangle
     end
 end
+
 
 @testset "Varying input in a discrete constrained linear control system" begin
     A = [1. 1; 1 -1]
@@ -105,108 +260,6 @@ end
     for ui in s.U
         @test ui isa Hyperrectangle
     end
-    @test islinear(s) && isaffine(s) && !ispolynomial(s)
-end
-
-@testset "Polynomial system in discrete time" begin
-    @polyvar x y
-    p = 2x^2 - 3x + y
-    s = PolynomialDiscreteSystem(p)
-    @test statedim(s) == 2
-    @test inputdim(s) == 0
-    @test !islinear(s) && !isaffine(s) && ispolynomial(s)
-end
-
-@testset "Polynomial system in discrete time with state constraints" begin
-    @polyvar x y
-    p = 2x^2 - 3x + y
-    X = BallInf(zeros(2), 0.1)
-    s = ConstrainedPolynomialDiscreteSystem(p, X)
-    @test statedim(s) == 2
-    @test inputdim(s) == 0
-    @test dim(stateset(s)) == dim(X)
-    @test !islinear(s) && !isaffine(s) && ispolynomial(s)
-end
-
-@testset "Implicit discrete system" begin
-    add_one(x) = x + 1
-    s = BlackBoxDiscreteSystem(add_one, 1)
-    x = 1.0
-    @test s.f(x) ≈ 2.0
-end
-
-@testset "Noisy Discrete constrained linear system" begin
-    A = [1. 1; 1 -1]
-    D = [1. 2; 0 1]
-    X = Line([1., -1], 0.) # line x = y
-    W = BallInf(zeros(2), 2.0)
-    s = NoisyConstrainedLinearDiscreteSystem(A, D, X, W)
-    @test statedim(s) == 2
-    @test stateset(s) == X
-    @test s.A == A
-    @test s.D == D
-    @test noisedim(s) == 2 == dim(W)
-    @test noiseset(s) == W
-    @test inputdim(s) == 0
-    @test islinear(s) && isaffine(s) && isnoisy(s)
-end
-
-@testset "Noisy Discrete constrained control linear system" begin
-    A = [1. 1; 1 -1]
-    B = Matrix([0.5 1.5]')
-    D = [1. 2; 0 1]
-    X = Line([1., -1], 0.) # line x = y
-    U = Hyperrectangle(low=[0.9], high=[1.1])
-    W = BallInf(zeros(2), 2.0)
-    s = NoisyConstrainedLinearControlDiscreteSystem(A, B, D, X, U, W)
-    @test statedim(s) == 2
-    @test stateset(s) == X
-    @test s.A == A
-    @test s.B == B
-    @test s.D == D
-    @test noisedim(s) == 2 == dim(W)
-    @test noiseset(s) == W
-    @test inputdim(s) == dim(U)
-    @test islinear(s) && isaffine(s) && isnoisy(s)
-end
-
-@testset "Noisy Discrete constrained control affine system" begin
-    A = [1. 1; 1 -1]
-    B = Matrix([0.5 1.5]')
-    c = [1.0, 0.5]
-    D = [1. 2; 0 1]
-    X = Line([1., -1], 0.) # line x = y
-    U = Hyperrectangle(low=[0.9], high=[1.1])
-    W = BallInf(zeros(2), 2.0)
-    s = NoisyConstrainedAffineControlDiscreteSystem(A, B, c, D, X, U, W)
-    @test statedim(s) == 2
-    @test stateset(s) == X
-    @test s.A == A
-    @test s.B == B
-    @test s.c == c
-    @test s.D == D
-    @test noisedim(s) == 2 == dim(W)
-    @test noiseset(s) == W
-    @test inputdim(s) == dim(U)
-    @test isaffine(s) && isnoisy(s)
-end
-
-@testset "Noisy Discrete constrained control blackbox system" begin
-    n = 2
-    m = 1
-    l = 2
-    f(x,u,w) = ones(n,n)*x + ones(n,m)*u + ones(n,l)*w
-    X = BallInf(zeros(n), 1.0)
-    U =  BallInf(zeros(m), 1.0)
-    W =  BallInf(zeros(l), 1.0)
-    s = NoisyConstrainedBlackBoxControlDiscreteSystem(f, n, m, l, X, U, W)
-    @test statedim(s) == n
-    @test s.f == f
-    @test stateset(s) == X
-    @test noisedim(s) == l == dim(W)
-    @test noiseset(s) == W
-    @test inputdim(s) == dim(U)
-    @test !islinear(s) && !isaffine(s) && isnoisy(s)
 end
 
 @testset "Successor state of a constrained discrete system" begin

--- a/test/discrete.jl
+++ b/test/discrete.jl
@@ -135,8 +135,6 @@ end
     @test s.f(x) ≈ 2.0
 end
 
-
-# Noisy
 @testset "Noisy Discrete constrained linear system" begin
     A = [1. 1; 1 -1]
     D = [1. 2; 0 1]
@@ -151,9 +149,6 @@ end
     @test noiseset(s) == W
     @test inputdim(s) == 0
     @test islinear(s) && isaffine(s) && isnoisy(s)
-    # if D is omitted, add the identiy matrix
-    s2 = NoisyConstrainedLinearDiscreteSystem(A, X, W)
-    @test s2.D == [1. 0; 0 1]
 end
 
 @testset "Noisy Discrete constrained control linear system" begin
@@ -173,9 +168,6 @@ end
     @test noiseset(s) == W
     @test inputdim(s) == dim(U)
     @test islinear(s) && isaffine(s) && isnoisy(s)
-    # if D is omitted, add the identiy matrix
-    s2 = NoisyConstrainedLinearControlDiscreteSystem(A, B, X, U, W)
-    @test s2.D == [1. 0; 0 1]
 end
 
 @testset "Noisy Discrete constrained control affine system" begin
@@ -197,9 +189,6 @@ end
     @test noiseset(s) == W
     @test inputdim(s) == dim(U)
     @test isaffine(s) && isnoisy(s)
-    # if D is omitted, add the identiy matrix
-    s2 = NoisyConstrainedAffineControlDiscreteSystem(A, B, c, X, U, W)
-    @test s2.D == [1. 0; 0 1]
 end
 
 @testset "Noisy Discrete constrained control blackbox system" begin
@@ -218,5 +207,4 @@ end
     @test noiseset(s) == W
     @test inputdim(s) == dim(U)
     @test !islinear(s) && !isaffine(s) && isnoisy(s)
-    # s = NoisyConstrainedBlackBoxControlDiscreteSystem(f, X, U, W)
 end

--- a/test/discrete.jl
+++ b/test/discrete.jl
@@ -209,7 +209,7 @@ end
     @test stateset(s) == X
     @test inputset(s) == U
     @test noiseset(s) == W
-    @test isaffine(s) && isnoisy(s) && !ispolynomial(s)
+    @test isaffine(s) && !islinear(s) && !ispolynomial(s)
     @test isnoisy(s) && iscontrolled(s) && isconstrained(s)
 end
 


### PR DESCRIPTION
For completeness, I added an `iscontrolled`and `isconstrained` trait to all the types.

Additonally, I added the `noisedim(::s) = 0` to all types that are not "noisy" and 
I cleaned up the constructors such that the traits and methods are all in the same order and I did also some ordering of the runtests.