### PR TITLE
@system: make macro calls work without parentheses

### DIFF
--- a/test/@system.jl
+++ b/test/@system.jl
@@ -41,7 +41,7 @@ f1(x, u, w) = x'*x + u'*u + w'*w
 @testset "@system for continous identity systems" begin
     @test @system(x' = 0, dim: 2) == ContinuousIdentitySystem(2)
     sys = @system x' = 0 dim: 2
-    @test sys  == ContinuousIdentitySystem(2)
+    @test sys == ContinuousIdentitySystem(2)
 
     @test @system(x₁' = 0, dim=2) == ContinuousIdentitySystem(2)
 

--- a/test/@system.jl
+++ b/test/@system.jl
@@ -40,15 +40,22 @@ f1(x, u, w) = x'*x + u'*u + w'*w
 
 @testset "@system for continous identity systems" begin
     @test @system(x' = 0, dim: 2) == ContinuousIdentitySystem(2)
+    sys = @system x' = 0 dim: 2
+    @test sys  == ContinuousIdentitySystem(2)
+
     @test @system(x₁' = 0, dim=2) == ContinuousIdentitySystem(2)
 
     @test @system(x' = 0, dim: 2, x ∈ X) == ConstrainedContinuousIdentitySystem(2, X)
     @test @system(x' = 0, dim=2, x ∈ X1) == ConstrainedContinuousIdentitySystem(2, X)
+    sys = @system x' = 0 dim=2 x ∈ X1
+    @test sys == ConstrainedContinuousIdentitySystem(2, X)
 end
 
 @testset "@system for linear continous systems" begin
     @test @system(x' = A*x) == LinearContinuousSystem(A)
     @test @system(x1' = A1x1) == LinearContinuousSystem(A1)
+    sys = @system x1' = A1x1
+    @test sys == LinearContinuousSystem(A1)
 
     # automatic identification of rhs linearity
     @test @system(x' = -x) == LinearContinuousSystem(-1*IdentityMultiple(I,1))
@@ -57,6 +64,8 @@ end
 
     @test @system(x' = A*x, x ∈ X) == ConstrainedLinearContinuousSystem(A,X)
     @test @system(x1' = A1x1, x1 ∈ X1) == ConstrainedLinearContinuousSystem(A1,X1)
+    sys = @system x1' =A1x1     x1 ∈ X1
+    @test sys  == ConstrainedLinearContinuousSystem(A1,X1)
 end
 
 @testset "@system for linear control continuous systems" begin

--- a/test/@system.jl
+++ b/test/@system.jl
@@ -65,7 +65,7 @@ end
     @test @system(x' = A*x, x ∈ X) == ConstrainedLinearContinuousSystem(A,X)
     @test @system(x1' = A1x1, x1 ∈ X1) == ConstrainedLinearContinuousSystem(A1,X1)
     sys = @system x1' =A1x1     x1 ∈ X1
-    @test sys  == ConstrainedLinearContinuousSystem(A1,X1)
+    @test sys == ConstrainedLinearContinuousSystem(A1,X1)
 end
 
 @testset "@system for linear control continuous systems" begin


### PR DESCRIPTION
Complete an element of checklist in #133.

See [here](https://discourse.julialang.org/t/input-parsing-for-macros-without-parantheses/34068/3) , the solution is trivial 🙈

The syntax needs to be 
```julia
@system x' = Ax + Bu  x∈X u∈U
```
without the commas.

I added the corresponding tests