### PR TITLE
Fix scalar @system by converting arguments to matrices

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -517,19 +517,19 @@ julia> using MathematicalSystems: extract_sum
 
 julia> extract_sum([:(A1*x)], :x, :u, :w)
 1-element Array{Tuple{Any,Symbol},1}:
- (:(hcat(:A1)), :A)
+ (:(hcat(A1)), :A)
 
 julia> extract_sum([:(A1*x), :(B1*u), :c], :x, :u, :w)
 3-element Array{Tuple{Any,Symbol},1}:
- (:(hcat(:A1)), :A)
- (:(hcat(:B1)), :B)
- (:(vcat(:c)), :c)
+ (:(hcat(A1)), :A)
+ (:(hcat(B1)), :B)
+ (:(vcat(c)), :c)
 
 julia> extract_sum([:(A1*x7), :( B1*u7), :( B2*w7)], :x7, :u7, :w7)
 3-element Array{Tuple{Any,Symbol},1}:
- (:(hcat(:A1)), :A)
- (:(hcat(:B1)), :B)
- (:(vcat(:B2)), :D)
+ (:(hcat(A1)), :A)
+ (:(hcat(B1)), :B)
+ (:(vcat(B2)), :D)
 ```
 
 ### Notes

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -557,16 +557,16 @@ function extract_sum(summands, state::Symbol, input::Symbol, noise::Symbol)
     for summand in summands
         if @capture(summand, array_ * var_)
             if state == var
-                push!(params, (array, :A))
+                push!(params, (Expr(:call, :hcat, array), :A))
                 # obtain "state_dim" for later using in IdentityMultiple
                 state_dim =  Expr(:call, :size, :($array), 1)
                 got_state_dim = true
 
             elseif input == var
-                push!(params, (array, :B))
+                push!(params, (Expr(:call, :hcat, array), :B))
 
             elseif noise == var
-                push!(params, (array, :D))
+                push!(params, (Expr(:call, :hcat, array), :D))
 
             else
                 throw(ArgumentError("in the dynamic equation, the expression "*
@@ -574,11 +574,7 @@ function extract_sum(summands, state::Symbol, input::Symbol, noise::Symbol)
                 "or the noise term $noise"))
             end
         elseif @capture(summand, array_)
-            if got_state_dim
-                identity = :(I($state_dim))
-            else
-                identity = 1.0
-            end
+            identity = :(I($state_dim))
             # if array == variable: field value equals identity
             if state == array
                 push!(params, (identity, :A))
@@ -587,7 +583,7 @@ function extract_sum(summands, state::Symbol, input::Symbol, noise::Symbol)
             elseif noise == array
                 push!(params, (identity, :D))
             else
-                push!(params, (array, :c))
+                push!(params, (vcat(array), :c))
             end
         end
     end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -529,7 +529,7 @@ julia> extract_sum([:(A1*x7), :( B1*u7), :( B2*w7)], :x7, :u7, :w7)
 3-element Array{Tuple{Any,Symbol},1}:
  (:(hcat(A1)), :A)
  (:(hcat(B1)), :B)
- (:(vcat(B2)), :D)
+ (:(hcat(B2)), :D)
 ```
 
 ### Notes

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -583,7 +583,7 @@ function extract_sum(summands, state::Symbol, input::Symbol, noise::Symbol)
             elseif noise == array
                 push!(params, (identity, :D))
             else
-                push!(params, (vcat(array), :c))
+                push!(params, (Expr(:call, :vcat, array), :c))
             end
         end
     end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -517,19 +517,19 @@ julia> using MathematicalSystems: extract_sum
 
 julia> extract_sum([:(A1*x)], :x, :u, :w)
 1-element Array{Tuple{Any,Symbol},1}:
- (:A1, :A)
+ (:(hcat(:A1)), :A)
 
 julia> extract_sum([:(A1*x), :(B1*u), :c], :x, :u, :w)
 3-element Array{Tuple{Any,Symbol},1}:
- (:A1, :A)
- (:B1, :B)
- (:c, :c)
+ (:(hcat(:A1)), :A)
+ (:(hcat(:B1)), :B)
+ (:(vcat(:c)), :c)
 
 julia> extract_sum([:(A1*x7), :( B1*u7), :( B2*w7)], :x7, :u7, :w7)
 3-element Array{Tuple{Any,Symbol},1}:
- (:A1, :A)
- (:B1, :B)
- (:B2, :D)
+ (:(hcat(:A1)), :A)
+ (:(hcat(:B1)), :B)
+ (:(vcat(:B2)), :D)
 ```
 
 ### Notes

--- a/test/@system.jl
+++ b/test/@system.jl
@@ -97,9 +97,9 @@ end
     # scalar cases
     @test @system(x' = 0.5x + u) == LinearControlContinuousSystem(hcat(0.5), I(1.0, 1))
     @test @system(x' = 0.5x + 1.) == AffineContinuousSystem(hcat(0.5), vcat(1.))
-    @test @system(x' = x + u) == LinearControlContinuousSystem(hcat(1.), hcat(1.))
-    @test @system(x' = x + 0.1u) == LinearControlContinuousSystem(hcat(1.), hcat(0.1))
-    @test @system(x' = x + 0.1*u) == LinearControlContinuousSystem(hcat(1.), hcat(0.1))
+    @test @system(x' = x + u) == LinearControlContinuousSystem(I(1.0, 1), I(1.0, 1))
+    @test @system(x' = x + 0.1u) == LinearControlContinuousSystem(I(1.0, 1), hcat(0.1))
+    @test @system(x' = x + 0.1*u) == LinearControlContinuousSystem(I(1.0, 1), hcat(0.1))
     sys = @system(x' = 0.3x + 0.1u + 0.2, x∈X, u∈U)
     @test sys == ConstrainedAffineControlContinuousSystem(hcat(0.3), hcat(0.1), vcat(0.2), X, U)
 end

--- a/test/@system.jl
+++ b/test/@system.jl
@@ -93,6 +93,10 @@ end
     @test @system(w' = A*w + B*u_1) == LinearControlContinuousSystem(A, B)
     # similarily for x_ = A_*x_ + B_*u_ + c_
     @test @system(w' = A*w + B*u_1 + c, w∈X, u_1∈U) == ConstrainedAffineControlContinuousSystem(A, B, c, X, U)
+
+    # scalar cases
+    @test @system(x' = 0.5x + u) == LinearControlContinuousSystem(hcat(0.5), I(1.0, 1))
+    @test @system(x' = 0.5x + 1.) == AffineContinuousSystem(hcat(0.5), vcat(1.))
 end
 
 @testset "@system for linear algebraic continous systems" begin
@@ -251,8 +255,8 @@ end
     s = IVP(LinearContinuousSystem(I(-1.0, 1)), Interval(-1, 1))
     @test @system(x' = -1.0x, x(0) ∈ Interval(-1, 1)) == s
 
-    # similar for integers
-    s = IVP(LinearDiscreteSystem(I(-1, 1)), [1])
+    # discrete ivp in floating-point
+    s = IVP(LinearDiscreteSystem(I(-1.0, 1)), [1])
     @test @system(x⁺ = -x, x(0) ∈ [1]) == s
 
     # initial state assignment doesn't match state variable


### PR DESCRIPTION
Thinking about other solutions to handle scalar system in `@system`.

The problems with the constructor for scalar systems could be fixed by converting the argument with `hcat` and `vcat` to a `matrix` respectively a `vector`.

Basically, the same we did in the constructor for  `Number` arguments.
Which means, that from the point of the `@system` macro, the scalar constructor would not be needed.
