### PR TITLE
Handle arbitrary order of  set / rhs term specifcation in @system

### DIFF
--- a/docs/src/lib/internals.md
+++ b/docs/src/lib/internals.md
@@ -21,6 +21,7 @@ _corresponding_type
 _capture_dim
 extract_dyn_equation_parameters
 add_asterisk
+sort
 ```
 
 ## Querying expressions

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -675,11 +675,11 @@ to `order`.
 ### Example
 
 ```jldoctest
-julia> using MathematicalSystems: sort
+julia> using MathematicalSystems
 
 julia> parameters= [(:U1, :U), (:X1, :X), (:W1, :W)];
 
-julia> sort(parameters, (:X, :U, :W)
+julia> MathematicalSystems.sort(parameters, (:X, :U, :W))
 3-element Array{Tuple{Any,Symbol},1}:
  (:X1, :X)
  (:U1, :U)
@@ -687,7 +687,7 @@ julia> sort(parameters, (:X, :U, :W)
 
 julia>  parameters= [(:const, :c), (:A, :A)];
 
-julia> sort(parameters, (:A, :B, :c, :D)
+julia> MathematicalSystems.sort(parameters, (:A, :B, :c, :D))
 2-element Array{Tuple{Any,Symbol},1}:
  (:A, :A)
  (:const, :c)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -664,7 +664,7 @@ end
 """
     sort(parameters::Vector, order::Tuple)
 
-Returns a sorted vector `parameters` according to `order`.
+Filter and sort the vector `parameters` according to `order`.
 `parameters` is a vector that contains tuples where the second element of each
 `Tuple` is considered for the sorting according to `order`.
 
@@ -674,11 +674,11 @@ If a value of `order` is not contained in `parameters` the corresponding entry o
 ### Input
 
 - `parameters` -- vector of tuples
-- `order`    -- tuple of symbols
+- `order`      -- tuple of symbols
 
 ### Output
 
-Sorted `parameters` vector according to `order`.
+A new vector corresponding to `parameters` filtered and sorted according to `order`.
 """
 function sort(parameters::Vector, order::Tuple)
     order_parameters = []

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -696,7 +696,7 @@ julia> MathematicalSystems.sort(parameters, (:A, :B, :c, :D))
 ### Note
 
 `parameters` is a vector that contains tuples whose second element
-`Tuple` is considered for the sorting according to `order`.
+is considered for the sorting according to `order`.
 
 If a value of `order` is not contained in `parameters`, the corresponding entry of
 `order` will be omitted.

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -695,7 +695,7 @@ julia> MathematicalSystems.sort(parameters, (:A, :B, :c, :D))
 
 ### Note
 
-`parameters` is a vector that contains tuples where the second element of each
+`parameters` is a vector that contains tuples whose second element
 `Tuple` is considered for the sorting according to `order`.
 
 If a value of `order` is not contained in `parameters` the corresponding entry of

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -698,7 +698,7 @@ julia> MathematicalSystems.sort(parameters, (:A, :B, :c, :D))
 `parameters` is a vector that contains tuples whose second element
 `Tuple` is considered for the sorting according to `order`.
 
-If a value of `order` is not contained in `parameters` the corresponding entry of
+If a value of `order` is not contained in `parameters`, the corresponding entry of
 `order` will be omitted.
 """
 function sort(parameters::Vector{<:Tuple{Any, Symbol}}, order::NTuple{N, Symbol}) where {N}

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -363,8 +363,8 @@ and left-hand side of the dynamic equation `equation`.
 """
 function extract_dyn_equation_parameters(equation, state, input, noise, dim, AT)
     @capture(equation, lhs_ = rhscode_)
-    lhs_params = Any[]
-    rhs_params = Any[]
+    lhs_params = Vector{Tuple{Any, Symbol}}()
+    rhs_params = Vector{Tuple{Any, Symbol}}()
     # if a * is used on the lhs, the rhs is a code-block
     if  @capture(lhs, E_*x_)
         push!(lhs_params, (E, :E))
@@ -669,17 +669,40 @@ Filter and sort the vector `parameters` according to `order`.
 
 ### Output
 
-A new vector corresponding to `parameters` filtered and sorted according to `order`.
+A new vector of tuplescorresponding to `parameters` filtered and sorted according
+to `order`.
+
+### Example
+
+```jldoctest
+julia> using MathematicalSystems: sort
+
+julia> parameters= [(:U1, :U), (:X1, :X), (:W1, :W)];
+
+julia> sort(parameters, (:X, :U, :W)
+3-element Array{Tuple{Any,Symbol},1}:
+ (:X1, :X)
+ (:U1, :U)
+ (:W1, :W)
+
+julia>  parameters= [(:const, :c), (:A, :A)];
+
+julia> sort(parameters, (:A, :B, :c, :D)
+2-element Array{Tuple{Any,Symbol},1}:
+ (:A, :A)
+ (:const, :c)
+```
 
 ### Note
+
 `parameters` is a vector that contains tuples where the second element of each
 `Tuple` is considered for the sorting according to `order`.
 
 If a value of `order` is not contained in `parameters` the corresponding entry of
 `order` will be omitted.
 """
-function sort(parameters::Vector, order::Tuple)
-    order_parameters = []
+function sort(parameters::Vector{<:Tuple{Any, Symbol}}, order::NTuple{N, Symbol}) where {N}
+    order_parameters = Vector{Tuple{Any, Symbol}}()
     for ordered_element in order
         for tuple in parameters
             if tuple[2] == ordered_element

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -4,6 +4,7 @@ using MacroTools: @capture
 using InteractiveUtils: subtypes
 export @system
 
+import Base: sort
 
 # ========================
 # @map macro
@@ -661,7 +662,6 @@ end
 
 Filter and sort the vector `parameters` according to `order`.
 
-
 ### Input
 
 - `parameters` -- vector of tuples
@@ -672,28 +672,26 @@ Filter and sort the vector `parameters` according to `order`.
 A new vector of tuples corresponding to `parameters` filtered and sorted according
 to `order`.
 
-### Example
+### Examples
 
 ```jldoctest
-julia> using MathematicalSystems
-
 julia> parameters= [(:U1, :U), (:X1, :X), (:W1, :W)];
 
-julia> MathematicalSystems.sort(parameters, (:X, :U, :W))
+julia> sort(parameters, (:X, :U, :W))
 3-element Array{Tuple{Any,Symbol},1}:
  (:X1, :X)
  (:U1, :U)
  (:W1, :W)
 
-julia>  parameters= [(:const, :c), (:A, :A)];
+julia>  parameters = [(:const, :c), (:A, :A)];
 
-julia> MathematicalSystems.sort(parameters, (:A, :B, :c, :D))
+julia> sort(parameters, (:A, :B, :c, :D))
 2-element Array{Tuple{Any,Symbol},1}:
  (:A, :A)
  (:const, :c)
 ```
 
-### Note
+### Notes
 
 `parameters` is a vector that contains tuples whose second element
 is considered for the sorting according to `order`.

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -660,11 +660,7 @@ end
     sort(parameters::Vector, order::Tuple)
 
 Filter and sort the vector `parameters` according to `order`.
-`parameters` is a vector that contains tuples where the second element of each
-`Tuple` is considered for the sorting according to `order`.
 
-If a value of `order` is not contained in `parameters` the corresponding entry of
-`order` will be omitted.
 
 ### Input
 
@@ -674,6 +670,13 @@ If a value of `order` is not contained in `parameters` the corresponding entry o
 ### Output
 
 A new vector corresponding to `parameters` filtered and sorted according to `order`.
+
+### Note
+`parameters` is a vector that contains tuples where the second element of each
+`Tuple` is considered for the sorting according to `order`.
+
+If a value of `order` is not contained in `parameters` the corresponding entry of
+`order` will be omitted.
 """
 function sort(parameters::Vector, order::Tuple)
     order_parameters = []

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -656,11 +656,6 @@ function extract_set_parameter(expr, state, input, noise) # input => to check se
     throw(ArgumentError("the set entry $(expr) does not have the correct form `x_ ∈ X_`"))
 end
 
-# Sort the parameter `parameters` such that it has the order `order` (e.g. (:X, :U, :W))
-# allowing for arbitrary order of  parameters which is a array of tuple, where the second
-# element of each tuple is the relevant value for the ordering. If a value of `order`
-# is not contained in `parameters` it will be ignored.
-
 """
     sort(parameters::Vector, order::Tuple)
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -669,7 +669,7 @@ Filter and sort the vector `parameters` according to `order`.
 
 ### Output
 
-A new vector of tuplescorresponding to `parameters` filtered and sorted according
+A new vector of tuples corresponding to `parameters` filtered and sorted according
 to `order`.
 
 ### Example

--- a/test/@system.jl
+++ b/test/@system.jl
@@ -28,16 +28,29 @@ f1(x, u, w) = x'*x + u'*u + w'*w
 
 
 # ===================
-# Test to fix in next PR
+# Error Handling
 # ===================
+@testset "@system miscellaneous" begin
+    @testset "@system for arbitrary order of set specification" begin
+        sys = @system(x' = Ax + Bu, u∈U, x∈X)
+        @test sys == ConstrainedLinearControlContinuousSystem(A,B,X,U)
+        sys = @system(x' = Ax + Bu + Dw, u∈U, w∈W, x∈X)
+        @test sys == NoisyConstrainedLinearControlContinuousSystem(A,B,D,X,U,W)
+    end
+    @testset "@system for arbitrary order of rhs terms" begin
+        sys = @system(x' = Bu + Ax, u∈U, x∈X)
+        @test sys == ConstrainedLinearControlContinuousSystem(A,B,X,U)
+        sys = @system(x' = Dw + Ax + Bu , u∈U, w∈W, x∈X)
+        @test sys == NoisyConstrainedLinearControlContinuousSystem(A,B,D,X,U,W)
+        sys = @system(x' = c + Ax + Bu , u∈U, x∈X)
+        @test sys == ConstrainedAffineControlContinuousSystem(A,B,c,X,U)
+    end
+end
 
-# sys = @system(x' = Ax + Bu, u∈U, x∈X)
-# sys == ConstrainedLinearControlContinuousSystem(A,B,X,U)
 
 # ===================
 # Continuous systems
 # ===================
-
 @testset "@system for continous identity systems" begin
     @test @system(x' = 0, dim: 2) == ContinuousIdentitySystem(2)
     sys = @system x' = 0 dim: 2


### PR DESCRIPTION
Closes an element of #133 

The order of the set specification can be arbitrary now.

Additionally, it allows for arbitrary order of rhs term specification in the dynamic equation.

See test for an example.