### PR TITLE
Return nothing for getter methods that are not supported

### DIFF
--- a/docs/src/lib/methods.md
+++ b/docs/src/lib/methods.md
@@ -29,6 +29,13 @@ inputset
 nextinput
 ```
 
+## Noises
+
+```@docs
+noisedim
+noiseset
+```
+
 ## Output
 
 ```@docs

--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -10,28 +10,42 @@ abstract type AbstractSystem end
 
 Returns the dimension of the state space of system `s`.
 """
-function statedim end
+statedim(::AbstractSystem) = nothing
 
 """
     stateset(s::AbstractSystem)
 
 Returns the set of allowed states of system `s`.
 """
-function stateset end
+stateset(::AbstractSystem) = nothing
 
 """
     inputdim(s::AbstractSystem)
 
 Returns the dimension of the input space of system `s`.
 """
-function inputdim end
+inputdim(::AbstractSystem) = nothing
 
 """
     inputset(s::AbstractSystem)
 
 Returns the set of allowed inputs of system `s`.
 """
-function inputset end
+inputset(::AbstractSystem) = nothing
+
+"""
+    noisedim(s::AbstractSystem)
+
+Returns the dimension of the noise space of system `s`.
+"""
+noisedim(::AbstractSystem) = nothing
+
+"""
+    noiseset(s::AbstractSystem)
+
+Returns the set of allowed noises of system `s`.
+"""
+noiseset(::AbstractSystem) = nothing
 
 """
     AbstractDiscreteSystem
@@ -152,14 +166,14 @@ abstract type AbstractMap end
 
 Returns the dimension of the output space of the map `m`.
 """
-function outputdim end
+outputdim(::AbstractMap) = nothing
 
 """
     outputmap(s::SystemWithOutput)
 
 Returns the output map of a system with output.
 """
-function outputmap end
+outputmap(::AbstractSystem) = nothing
 
 """
     islinear(m::AbstractMap)
@@ -193,7 +207,7 @@ Apply the rule specified by the map to the given arguments.
 function apply end
 
 """
-    state_matrix(::AbstractSystem)
+    state_matrix(s::AbstractSystem)
 
 Return the state matrix of an affine system.
 
@@ -202,10 +216,10 @@ Return the state matrix of an affine system.
 The state matrix is the matrix proportional to the state, e.g. the matrix `A`
 in the linear continuous system ``x' = Ax``.
 """
-state_matrix(::AbstractSystem)
+state_matrix(::AbstractSystem) = nothing
 
 """
-    input_matrix(::AbstractSystem)
+    input_matrix(s::AbstractSystem)
 
 Return the input matrix of a system with linear input.
 
@@ -214,10 +228,10 @@ Return the input matrix of a system with linear input.
 The input matrix is the matrix proportional to the input, e.g. the matrix `B`
 in the linear continuous system with input, ``x' = Ax + Bu``.
 """
-input_matrix(::AbstractSystem)
+input_matrix(::AbstractSystem) = nothing
 
 """
-    noise_matrix(::AbstractSystem)
+    noise_matrix(s::AbstractSystem)
 
 Return the noise matrix of a system with linear noise.
 
@@ -226,10 +240,10 @@ Return the noise matrix of a system with linear noise.
 The noise matrix is the matrix proportional to the noise, e.g. the matrix `D`
 in the linear system with noise, ``x' = Ax + Dw``.
 """
-noise_matrix(::AbstractSystem)
+noise_matrix(::AbstractSystem) = nothing
 
 """
-    affine_term(::AbstractSystem)
+    affine_term(s::AbstractSystem)
 
 Return the affine term in an affine system.
 
@@ -237,4 +251,4 @@ Return the affine term in an affine system.
 
 The affine term is e.g. the vector ``c`` in the affine system ``x' = Ax + c``.
 """
-affine_term(::AbstractSystem)
+affine_term(::AbstractSystem) = nothing

--- a/src/outputs.jl
+++ b/src/outputs.jl
@@ -1,5 +1,5 @@
 """
-    SystemWithOutput{ST<:AbstractSystem, MT<:AbstractMap}
+    SystemWithOutput{ST<:AbstractSystem, MT<:AbstractMap} <: AbstractSystem
 
 Parametric composite type for systems with outputs. It is parameterized in the
 system's type (`ST`) and in the map's type (`MT`).
@@ -9,7 +9,7 @@ system's type (`ST`) and in the map's type (`MT`).
 - `s`         -- system of type `ST`
 - `outputmap` -- output map of type `MT`
 """
-struct SystemWithOutput{ST<:AbstractSystem, MT<:AbstractMap}
+struct SystemWithOutput{ST<:AbstractSystem, MT<:AbstractMap} <: AbstractSystem
     s::ST
     outputmap::MT
 end

--- a/test/continuous.jl
+++ b/test/continuous.jl
@@ -1,248 +1,301 @@
+# linear systems
+E = [0. 1; 1 0]
+A = [1. 1; 1 -1]
+B = Matrix([0.5 1.5]')
+C = [1.; 1.]
+D = [1. 2; 0 1]
+X = Line([1., -1], 0.) # line x = y
+U = Interval(0.9, 1.1)
+W = BallInf(zeros(2), 2.0)
+sd = 2
+id = 1
+nd = 2
+
+# polynomial system
+@polyvar x y
+p = 2x^2 - 3x + y
+sdp = 2
+
+# blackbox system
+add_one(x) = x .+ 1
+add_one(x, u) = x .+ 1 .+ u
+add_one(x, u, w) = x .+ 1 .+ u .+ w
+state = [1.0; 2.0]
+input = 1
+noise = [3.0; 1.0]
+statePlusOne = add_one(state)
+stateInputPlusOne = add_one(state, input)
+stateInputNoisePlusOne = add_one(state, input, noise)
+
+# Scalar System
+a = 1.; b = 2.; c = 0.1; d = 3.; Xs = 1; Us = 2; Ws = 3; e = 2.;
+As = [a][:,:]; Bs = [b][:,:]; Cs = [c]; Ds = [d][:,:]; Es = [e][:,:]
+
+
+
 @testset "Continuous identity system" begin
-    for sd in 1:3
-        s = ContinuousIdentitySystem(sd)
-        @test statedim(s) == sd
-        @test inputdim(s) == 0
-        @test noisedim(s) == 0
-        for s = [s, typeof(s)]
-            @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
-            @test !isnoisy(s) && !iscontrolled(s) && !isconstrained(s)
-        end
+    s = ContinuousIdentitySystem(sd)
+    @test state_matrix(s) == I(sd)
+    @test input_matrix(s) == nothing
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == nothing
+    @test statedim(s) == sd
+    @test inputdim(s) == 0
+    @test noisedim(s) == 0
+    @test stateset(s) == nothing
+    @test inputset(s) == nothing
+    @test noiseset(s) == nothing
+    for s = [s, typeof(s)]
+        @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
+        @test !isnoisy(s) && !iscontrolled(s) && !isconstrained(s)
     end
 end
 
 @testset "Continuous constrained identity system" begin
-    for sd in 1:3
-        X = Singleton(ones(sd))
-        s = ConstrainedContinuousIdentitySystem(sd, X)
-        @test statedim(s) == sd
-        @test inputdim(s) == 0
-        @test noisedim(s) == 0
-        @test stateset(s) == X
-        for s = [s, typeof(s)]
-            @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
-            @test !isnoisy(s) && !iscontrolled(s) && isconstrained(s)
-        end
+    s = ConstrainedContinuousIdentitySystem(sd, X)
+    @test state_matrix(s) == I(sd)
+    @test input_matrix(s) == nothing
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == nothing
+    @test statedim(s) == sd
+    @test inputdim(s) == 0
+    @test noisedim(s) == 0
+    @test stateset(s) == X
+    @test inputset(s) == nothing
+    @test noiseset(s) == nothing
+    for s = [s, typeof(s)]
+        @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
+        @test !isnoisy(s) && !iscontrolled(s) && isconstrained(s)
     end
 end
 
 @testset "Continuous linear system" begin
-    for sd in 1:3
-        s = LinearContinuousSystem(zeros(sd, sd))
-        @test statedim(s) == sd
-        @test inputdim(s) == 0
-        @test noisedim(s) == 0
-        for s = [s, typeof(s)]
-            @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
-            @test !isnoisy(s) && !iscontrolled(s) && !isconstrained(s)
-        end
+    s = LinearContinuousSystem(A)
+    @test state_matrix(s) == A
+    @test input_matrix(s) == nothing
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == nothing
+    @test statedim(s) == sd
+    @test inputdim(s) == 0
+    @test noisedim(s) == 0
+    @test stateset(s) == nothing
+    @test inputset(s) == nothing
+    @test noiseset(s) == nothing
+    for s = [s, typeof(s)]
+        @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
+        @test !isnoisy(s) && !iscontrolled(s) && !isconstrained(s)
     end
     # Scalar System
-    a = 1.
-    A = [a][:,:]
     scalar_sys = LinearContinuousSystem(a)
-    @test scalar_sys == LinearContinuousSystem(A)
+    @test scalar_sys == LinearContinuousSystem(As)
 end
 
 @testset "Continuous affine system" begin
-    for sd in 1:3
-        s = AffineContinuousSystem(zeros(sd, sd), zeros(sd))
-        @test statedim(s) == sd
-        @test inputdim(s) == 0
-        for s = [s, typeof(s)]
-            @test !islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
-            @test !isnoisy(s) && !iscontrolled(s) && !isconstrained(s)
-        end
+    s = AffineContinuousSystem(A, C)
+    @test state_matrix(s) == A
+    @test input_matrix(s) == nothing
+    @test affine_term(s) == C
+    @test noise_matrix(s) == nothing
+    @test statedim(s) == sd
+    @test inputdim(s) == 0
+    @test noisedim(s) == 0
+    @test stateset(s) == nothing
+    @test inputset(s) == nothing
+    @test noiseset(s) == nothing
+    for s = [s, typeof(s)]
+        @test !islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
+        @test !isnoisy(s) && !iscontrolled(s) && !isconstrained(s)
     end
     # Scalar System
-    a = 1.; c = 0.1
-    A = [a][:,:]; C = [c]
     scalar_sys = AffineContinuousSystem(a, c)
-    @test scalar_sys == AffineContinuousSystem(A, C)
+    @test scalar_sys == AffineContinuousSystem(As, Cs)
 end
 
 @testset "Continuous linear control system" begin
-    for sd in 1:3
-        s = LinearControlContinuousSystem(zeros(sd, sd), ones(sd, sd))
-        @test statedim(s) == sd
-        @test inputdim(s) == sd
-        @test noisedim(s) == 0
-        for s = [s, typeof(s)]
-            @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
-            @test !isnoisy(s) && iscontrolled(s) && !isconstrained(s)
-        end
+    s = LinearControlContinuousSystem(A, B)
+    @test state_matrix(s) == A
+    @test input_matrix(s) == B
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == nothing
+    @test statedim(s) == sd
+    @test inputdim(s) == id
+    @test noisedim(s) == 0
+    @test stateset(s) == nothing
+    @test inputset(s) == nothing
+    @test noiseset(s) == nothing
+    for s = [s, typeof(s)]
+        @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
+        @test !isnoisy(s) && iscontrolled(s) && !isconstrained(s)
     end
     # Scalar System
-    a = 1.; b = 2.
-    A = [a][:,:]; B = [b][:,:]
     scalar_sys = LinearControlContinuousSystem(a, b)
-    @test scalar_sys == LinearControlContinuousSystem(A, B)
+    @test scalar_sys == LinearControlContinuousSystem(As, Bs)
 end
 
 @testset "Continuous constrained linear system" begin
-    A = [1. 1; 1 -1]
-    X = Line([1., -1], 0.) # line x = y
     s = ConstrainedLinearContinuousSystem(A, X)
-    @test statedim(s) == 2
+    @test state_matrix(s) == A
+    @test input_matrix(s) == nothing
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == nothing
+    @test statedim(s) == sd
     @test inputdim(s) == 0
     @test noisedim(s) == 0
     @test stateset(s) == X
+    @test inputset(s) == nothing
+    @test noiseset(s) == nothing
     for s = [s, typeof(s)]
         @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
         @test !isnoisy(s) && !iscontrolled(s) && isconstrained(s)
     end
     # Scalar System
-    a = 1.; X = 1
-    A = [a][:,:]
-    scalar_sys = ConstrainedLinearContinuousSystem(a, X)
-    @test scalar_sys == ConstrainedLinearContinuousSystem(A, X)
+    scalar_sys = ConstrainedLinearContinuousSystem(a, Xs)
+    @test scalar_sys == ConstrainedLinearContinuousSystem(As, Xs)
 end
 
 @testset "Continuous constrained affine system" begin
-    A = [1. 1; 1 -1]
-    c = [1.; 1.]
-    X = Line([1., -1], 0.) # line x = y
-    s = ConstrainedAffineContinuousSystem(A, c, X)
-    @test statedim(s) == 2
+    s = ConstrainedAffineContinuousSystem(A, C, X)
+    @test state_matrix(s) == A
+    @test input_matrix(s) == nothing
+    @test affine_term(s) == C
+    @test noise_matrix(s) == nothing
+    @test statedim(s) == sd
     @test inputdim(s) == 0
     @test noisedim(s) == 0
     @test stateset(s) == X
+    @test inputset(s) == nothing
+    @test noiseset(s) == nothing
     for s = [s, typeof(s)]
         @test !islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
         @test !isnoisy(s) && !iscontrolled(s) && isconstrained(s)
     end
     # Scalar System
-    a = 1.; c = 0.1; X = 1
-    A = [a][:,:]; C = [c]
-    scalar_sys = ConstrainedAffineContinuousSystem(a, c, X)
-    @test scalar_sys == ConstrainedAffineContinuousSystem(A, C, X)
+    scalar_sys = ConstrainedAffineContinuousSystem(a, c, Xs)
+    @test scalar_sys == ConstrainedAffineContinuousSystem(As, Cs, Xs)
 end
 
 @testset "Continuous affine control system with state constraints" begin
-    A = zeros(2, 2)
-    B = Matrix([0.5 1.5]')
-    c = [0.0, 1.0]
-    X = Line([1., -1], 0.) # line x = y
-    U = Interval(-1.0, 1.0)  # -1 <= u <= 1
-    s = ConstrainedAffineControlContinuousSystem(A, B, c, X, U)
-    @test statedim(s) == 2
-    @test inputdim(s) == 1
+    s = ConstrainedAffineControlContinuousSystem(A, B, C, X, U)
+    @test state_matrix(s) == A
+    @test input_matrix(s) == B
+    @test affine_term(s) == C
+    @test noise_matrix(s) == nothing
+    @test statedim(s) == sd
+    @test inputdim(s) == id
     @test noisedim(s) == 0
     @test stateset(s) == X
     @test inputset(s) == U
+    @test noiseset(s) == nothing
     for s = [s, typeof(s)]
         @test !islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
         @test !isnoisy(s) && iscontrolled(s) && isconstrained(s)
     end
     # Scalar System
-    a = 1.; b = 2.; c = 0.1; X = 1; U = 2
-    A = [a][:,:]; B = [b][:,:]; C = [c]
-    scalar_sys = ConstrainedAffineControlContinuousSystem(a, b, c, X, U)
-    @test scalar_sys == ConstrainedAffineControlContinuousSystem(A, B, C, X, U)
+    scalar_sys = ConstrainedAffineControlContinuousSystem(a, b, c, Xs, Us)
+    @test scalar_sys == ConstrainedAffineControlContinuousSystem(As, Bs, Cs, Xs, Us)
 end
 
 @testset "Continuous constrained linear control system" begin
-    A = [1. 1; 1 -1]
-    B = Matrix([0.5 1.5]')
-    X = Line([1., -1], 0.)
-    U = Interval(0.9, 1.1)
     s = ConstrainedLinearControlContinuousSystem(A, B, X, U)
-    @test statedim(s) == 2
-    @test inputdim(s) == 1
+    @test state_matrix(s) == A
+    @test input_matrix(s) == B
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == nothing
+    @test statedim(s) == sd
+    @test inputdim(s) == id
     @test noisedim(s) == 0
     @test stateset(s) == X
     @test inputset(s) == U
+    @test noiseset(s) == nothing
     for s = [s, typeof(s)]
         @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
         @test !isnoisy(s) && iscontrolled(s) && isconstrained(s)
     end
-    # initial value problem composite type
-    x0 = Singleton([1.5, 2.0])
-    p = InitialValueProblem(s, x0)
-    @test initial_state(p) == x0
-    @test system(p) == s
-    @test inputset(p) == U
-    @test statedim(p) == 2
-    @test inputdim(p) == 1
+
+    @testset "initial value problem composite type" begin
+        x0 = Singleton([1.5, 2.0])
+        ivp = InitialValueProblem(s, x0)
+        @test initial_state(ivp) == x0
+        @test system(ivp) == s
+        @test inputset(ivp) == U
+        @test statedim(ivp) == 2
+        @test inputdim(ivp) == 1
+    end
 
     # check that the matrices A and B need not be of the same type
     # with A dense and B a lazy adjoint
-    B = [0.5 1.5]'
-    s = ConstrainedLinearControlContinuousSystem(A, B, X, U)
+    B_adjoint = [0.5 1.5]'
+    s = ConstrainedLinearControlContinuousSystem(A, B_adjoint, X, U)
 
     # check that the matrices A and B need not be of the same type
     # with A sparse and B a lazy adjoint
-    A = sparse([1], [2], [1.0], 2, 2) # sparse matrix
-    s = ConstrainedLinearControlContinuousSystem(A, B, X, U)
+    A_sparse = sparse([1], [2], [1.0], 2, 2) # sparse matrix
+    s = ConstrainedLinearControlContinuousSystem(A_sparse, B, X, U)
 end
 
 @testset "Continuous linear algebraic system" begin
-    for sd in 1:3
-        s = LinearAlgebraicContinuousSystem(zeros(sd, sd), zeros(sd, sd))
-        @test statedim(s) == sd
-        @test inputdim(s) == 0
-        @test noisedim(s) == 0
-        for s = [s, typeof(s)]
-            @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
-            @test !isnoisy(s) && !iscontrolled(s) && !isconstrained(s)
-        end
-    end
+    s = LinearAlgebraicContinuousSystem(A, E)
+    @test state_matrix(s) == A
+    @test input_matrix(s) == nothing
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == nothing
+    @test s.E == E
+    @test statedim(s) == sd
+    @test inputdim(s) == 0
+    @test noisedim(s) == 0
+    @test stateset(s) == nothing
+    @test inputset(s) == nothing
+    @test noiseset(s) == nothing
     # Scalar System
-    a = 1.; e = 2.
-    A = [a][:,:]; E = [e][:,:]
     scalar_sys = LinearAlgebraicContinuousSystem(a, e)
-    @test scalar_sys == LinearAlgebraicContinuousSystem(A, E)
+    @test scalar_sys == LinearAlgebraicContinuousSystem(As, Es)
 end
 
 @testset "Continuous constrained linear algebraic system" begin
-    A = [1. 1; 1 -1]
-    E = [0. 1; 1 0]
-    X = LinearConstraint([0, -1.], 0.) # the set y ≥ 0
     s = ConstrainedLinearAlgebraicContinuousSystem(A, E, X)
-    @test statedim(s) == 2
+    @test state_matrix(s) == A
+    @test input_matrix(s) == nothing
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == nothing
+    @test s.E == E
+    @test statedim(s) == sd
     @test inputdim(s) == 0
     @test noisedim(s) == 0
     @test stateset(s) == X
+    @test inputset(s) == nothing
+    @test noiseset(s) == nothing
     for s = [s, typeof(s)]
         @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
         @test !isnoisy(s) && !iscontrolled(s) && isconstrained(s)
     end
     # Scalar System
-    a = 1.; e = 2.; X = 1
-    A = [a][:,:]; E = [e][:,:]
-    scalar_sys = ConstrainedLinearAlgebraicContinuousSystem(a, e, X)
-    @test scalar_sys == ConstrainedLinearAlgebraicContinuousSystem(A, E, X)
-end
+    scalar_sys = ConstrainedLinearAlgebraicContinuousSystem(a, e, Xs)
+    @test scalar_sys == ConstrainedLinearAlgebraicContinuousSystem(As, Es, Xs)
 
-@testset "Initial value problem for a continuous constrained linear algebraic system" begin
-    A = [1. 1; 1 -1]
-    E = [0. 1; 1 0]
-    X = LinearConstraint([0, -1.], 0.) # the set y ≥ 0
-    s = ConstrainedLinearAlgebraicContinuousSystem(A, E, X)
-    @test statedim(s) == 2
-    @test inputdim(s) == 0
-    @test noisedim(s) == 0
-    @test stateset(s) == X
-    for s = [s, typeof(s)]
-        @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
-        @test !isnoisy(s) && !iscontrolled(s) && isconstrained(s)
+    @testset "Initial value problem" begin
+        x0 = Singleton([1.5, 2.0])
+        ivp = IVP(s, x0)
+        # getter functions
+        @test initial_state(ivp) == x0
     end
-
-    x0 = Singleton([1.5, 2.0])
-    p = IVP(s, x0)
-    # getter functions
-    @test initial_state(p) == x0
 end
+
+
 
 @testset "Polynomial system in continuous time" begin
-    @polyvar x y
-    p = 2x^2 - 3x + y
-
     # default constructor for scalar p and
     s = PolynomialContinuousSystem(p)
-    @test statedim(s) == 2
+    @test state_matrix(s) == nothing
+    @test input_matrix(s) == nothing
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == nothing
+    # @test s.p == p
+    @test statedim(s) == sdp
     @test inputdim(s) == 0
     @test noisedim(s) == 0
+    @test stateset(s) == nothing
+    @test inputset(s) == nothing
+    @test noiseset(s) == nothing
     for s = [s, typeof(s)]
         @test !islinear(s) && !isaffine(s) && ispolynomial(s) && !isblackbox(s)
         @test !isnoisy(s) && !iscontrolled(s) && !isconstrained(s)
@@ -256,16 +309,19 @@ end
 end
 
 @testset "Polynomial system in continuous time with state constraints" begin
-    @polyvar x y
-    p = 2x^2 - 3x + y
-    X = BallInf(zeros(2), 0.1)
-
     # default constructor for scalar p and
     s = ConstrainedPolynomialContinuousSystem(p, X)
-    @test statedim(s) == 2
+    @test state_matrix(s) == nothing
+    @test input_matrix(s) == nothing
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == nothing
+    # @test s.p == p
+    @test statedim(s) == sdp
     @test inputdim(s) == 0
     @test noisedim(s) == 0
-    @test dim(stateset(s)) == dim(X)
+    @test stateset(s) == X
+    @test inputset(s) == nothing
+    @test noiseset(s) == nothing
     for s = [s, typeof(s)]
         @test !islinear(s) && !isaffine(s) && ispolynomial(s) && !isblackbox(s)
         @test !isnoisy(s) && !iscontrolled(s) && isconstrained(s)
@@ -283,11 +339,22 @@ end
 
 @testset "Continuous system defined by a function" begin
     s = BlackBoxContinuousSystem(vanderpol!, 2)
+    @test state_matrix(s) == nothing
+    @test input_matrix(s) == nothing
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == nothing
+    @test statedim(s) == 2
+    @test inputdim(s) == 0
+    @test noisedim(s) == 0
+    @test stateset(s) == nothing
+    @test inputset(s) == nothing
+    @test noiseset(s) == nothing
     f! = (x, dx) -> s.f(x, dx)
     x = [1.0, 0.0]
     dx = similar(x)
     f!(x, dx)
     @test dx ≈ [0.0, -1.0]
+
     for s = [s, typeof(s)]
         @test !islinear(s) && !isaffine(s) && !ispolynomial(s) && isblackbox(s)
         @test !isnoisy(s) && !iscontrolled(s) && !isconstrained(s)
@@ -297,6 +364,16 @@ end
 @testset "Continuous system defined by a function with state constraints" begin
     H = HalfSpace([1.0, 0.0], 0.0) # x <= 0
     s = ConstrainedBlackBoxContinuousSystem(vanderpol!, 2, H)
+    @test state_matrix(s) == nothing
+    @test input_matrix(s) == nothing
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == nothing
+    @test statedim(s) == 2
+    @test inputdim(s) == 0
+    @test noisedim(s) == 0
+    @test stateset(s) == H
+    @test inputset(s) == nothing
+    @test noiseset(s) == nothing
     f! = (x, dx) -> s.f(x, dx)
     x = [1.0, 0.0]
     dx = similar(x)
@@ -317,9 +394,17 @@ end
 
 @testset "Continuous control black-box system" begin
     add_one(x) = x + 1
-    s = BlackBoxControlContinuousSystem(add_one, 2, 1)
+    s = BlackBoxControlContinuousSystem(vanderpol_controlled!, 2, 1)
+    @test state_matrix(s) == nothing
+    @test input_matrix(s) == nothing
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == nothing
     @test statedim(s) == 2
     @test inputdim(s) == 1
+    @test noisedim(s) == 0
+    @test stateset(s) == nothing
+    @test inputset(s) == nothing
+    @test noiseset(s) == nothing
     for s = [s, typeof(s)]
         @test !islinear(s) && !isaffine(s) && !ispolynomial(s) && isblackbox(s)
         @test !isnoisy(s) && iscontrolled(s) && !isconstrained(s)
@@ -330,16 +415,22 @@ end
     H = HalfSpace([1.0, 0.0], 0.0) # x <= 0
     U = Interval(-0.1, 0.1)
     s = ConstrainedBlackBoxControlContinuousSystem(vanderpol_controlled!, 2, 1, H, U)
+    @test state_matrix(s) == nothing
+    @test input_matrix(s) == nothing
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == nothing
+    @test statedim(s) == 2
+    @test inputdim(s) == 1
+    @test noisedim(s) == 0
+    @test stateset(s) == H
+    @test inputset(s) == U
+    @test noiseset(s) == nothing
     f! = (x, u, dx) -> s.f(x, u, dx)
     x = [1.0, 0.0]
     u = an_element(U)
     dx = similar(x)
     f!(x, u, dx)
     @test dx ≈ [0.0, -1.0 + u[1]]
-    @test statedim(s) == 2
-    @test inputdim(s) == 1
-    @test stateset(s) == H
-    @test inputset(s) == U
     for s = [s, typeof(s)]
         @test !islinear(s) && !isaffine(s) && !ispolynomial(s) && isblackbox(s)
         @test !isnoisy(s) && iscontrolled(s) && isconstrained(s)
@@ -351,85 +442,77 @@ end
 # ==============
 
 @testset "Noisy continuous linear system" begin
-    A = [1. 1; 1 -1]
-    D = [1. 2; 0 1]
     s = NoisyLinearContinuousSystem(A, D)
-    @test s.A == A
-    @test s.D == D
-    @test statedim(s) == 2
+    @test state_matrix(s) == A
+    @test input_matrix(s) == nothing
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == D
+    @test statedim(s) == sd
     @test inputdim(s) == 0
-    @test noisedim(s) == 2
+    @test noisedim(s) == nd
+    @test stateset(s) == nothing
+    @test inputset(s) == nothing
+    @test noiseset(s) == nothing
     for s = [s, typeof(s)]
         @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
         @test isnoisy(s) && !iscontrolled(s) && !isconstrained(s)
     end
     # Scalar System
-    a = 1.; d = 3.
-    A = [a][:,:]; D = [d][:,:]
     scalar_sys = NoisyLinearContinuousSystem(a, d)
-    @test scalar_sys == NoisyLinearContinuousSystem(A, D)
+    @test scalar_sys == NoisyLinearContinuousSystem(As, Ds)
 end
 
 @testset "Noisy Continuous constrained linear system" begin
-    A = [1. 1; 1 -1]
-    D = [1. 2; 0 1]
-    X = Line([1., -1], 0.) # line x = y
-    W = BallInf(zeros(2), 2.0)
     s = NoisyConstrainedLinearContinuousSystem(A, D, X, W)
-    @test s.A == A
-    @test s.D == D
-    @test statedim(s) == 2
+    @test state_matrix(s) == A
+    @test input_matrix(s) == nothing
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == D
+    @test statedim(s) == sd
     @test inputdim(s) == 0
-    @test noisedim(s) == 2 == dim(W)
+    @test noisedim(s) == nd
     @test stateset(s) == X
+    @test inputset(s) == nothing
     @test noiseset(s) == W
     for s = [s, typeof(s)]
         @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
         @test isnoisy(s) && !iscontrolled(s) && isconstrained(s)
     end
     # Scalar System
-    a = 1.; d = 3.; X = 1; W = 3
-    A = [a][:,:]; D = [d][:,:]
-    scalar_sys = NoisyConstrainedLinearContinuousSystem(a, d, X, W)
-    @test scalar_sys == NoisyConstrainedLinearContinuousSystem(A, D, X, W)
+    scalar_sys = NoisyConstrainedLinearContinuousSystem(a, d, Xs, Ws)
+    @test scalar_sys == NoisyConstrainedLinearContinuousSystem(As, Ds, Xs, Ws)
 end
 
 @testset "Noisy continuous control linear system" begin
-    A = [1. 1; 1 -1]
-    B = Matrix([0.5 1.5]')
-    D = [1. 2; 0 1]
     s = NoisyLinearControlContinuousSystem(A, B, D)
-    @test s.A == A
-    @test s.B == B
-    @test s.D == D
-    @test statedim(s) == 2
-    @test inputdim(s) == 1
-    @test noisedim(s) == 2
+    @test state_matrix(s) == A
+    @test input_matrix(s) == B
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == D
+    @test statedim(s) == sd
+    @test inputdim(s) == id
+    @test noisedim(s) == nd
+    @test stateset(s) == nothing
+    @test inputset(s) == nothing
+    @test noiseset(s) == nothing
     for s = [s, typeof(s)]
         @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
         @test isnoisy(s) && iscontrolled(s) && !isconstrained(s)
     end
     # Scalar System
-    a = 1.; b = 2.; d = 3.
-    A = [a][:,:]; B = [b][:,:]; D = [d][:,:]
     scalar_sys = NoisyLinearControlContinuousSystem(a, b, d)
-    @test scalar_sys == NoisyLinearControlContinuousSystem(A, B, D)
+    @test scalar_sys == NoisyLinearControlContinuousSystem(As, Bs, Ds)
 end
 
 @testset "Noisy Continuous constrained control linear system" begin
-    A = [1. 1; 1 -1]
-    B = Matrix([0.5 1.5]')
-    D = [1. 2; 0 1]
-    X = Line([1., -1], 0.) # line x = y
-    U = Hyperrectangle(low=[0.9], high=[1.1])
-    W = BallInf(zeros(2), 2.0)
     s = NoisyConstrainedLinearControlContinuousSystem(A, B, D, X, U, W)
-    @test s.A == A
-    @test s.B == B
-    @test s.D == D
-    @test statedim(s) == 2
-    @test inputdim(s) == dim(U)
-    @test noisedim(s) == 2 == dim(W)
+    @test state_matrix(s) == A
+    @test input_matrix(s) == B
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == D
+    @test statedim(s) == sd
+    @test inputdim(s) == id
+    @test noisedim(s) == nd
     @test stateset(s) == X
     @test inputset(s) == U
     @test noiseset(s) == W
@@ -438,52 +521,40 @@ end
         @test isnoisy(s) && iscontrolled(s) && isconstrained(s)
     end
     # Scalar System
-    a = 1.; b = 2.; d = 3.; X = 1; U = 2; W = 3
-    A = [a][:,:]; B = [b][:,:]; D = [d][:,:]
-    scalar_sys = NoisyConstrainedLinearControlContinuousSystem(a, b, d, X, U, W)
-    @test scalar_sys == NoisyConstrainedLinearControlContinuousSystem(A, B, D, X, U, W)
+    scalar_sys = NoisyConstrainedLinearControlContinuousSystem(a, b, d, Xs, Us, Ws)
+    @test scalar_sys == NoisyConstrainedLinearControlContinuousSystem(As, Bs, Ds, Xs, Us, Ws)
 end
 
 @testset "Noisy continuous control affine system" begin
-    A = [1. 1; 1 -1]
-    B = Matrix([0.5 1.5]')
-    c = [1.0, 0.5]
-    D = [1. 2; 0 1]
-    s = NoisyAffineControlContinuousSystem(A, B, c, D)
-    @test s.A == A
-    @test s.B == B
-    @test s.c == c
-    @test s.D == D
-    @test statedim(s) == 2
-    @test inputdim(s) == 1
-    @test noisedim(s) == 2
+    s = NoisyAffineControlContinuousSystem(A, B, C, D)
+    @test state_matrix(s) == A
+    @test input_matrix(s) == B
+    @test affine_term(s) == C
+    @test noise_matrix(s) == D
+    @test statedim(s) == sd
+    @test inputdim(s) == id
+    @test noisedim(s) == nd
+    @test stateset(s) == nothing
+    @test inputset(s) == nothing
+    @test noiseset(s) == nothing
     for s = [s, typeof(s)]
         @test isaffine(s) && !islinear(s) && !ispolynomial(s) && !isblackbox(s)
         @test isnoisy(s) && iscontrolled(s) && !isconstrained(s)
     end
     # Scalar System
-    a = 1.; b = 2.; c = 0.1; d = 3.; X = 1; U = 2; W = 3
-    A = [a][:,:]; B = [b][:,:]; C = [c]; D = [d][:,:]
     scalar_sys = NoisyAffineControlContinuousSystem(a, b, c, d)
-    @test scalar_sys == NoisyAffineControlContinuousSystem(A, B, C, D)
+    @test scalar_sys == NoisyAffineControlContinuousSystem(As, Bs, Cs, Ds)
 end
 
 @testset "Noisy Continuous constrained control affine system" begin
-    A = [1. 1; 1 -1]
-    B = Matrix([0.5 1.5]')
-    c = [1.0, 0.5]
-    D = [1. 2; 0 1]
-    X = Line([1., -1], 0.) # line x = y
-    U = Hyperrectangle(low=[0.9], high=[1.1])
-    W = BallInf(zeros(2), 2.0)
-    s = NoisyConstrainedAffineControlContinuousSystem(A, B, c, D, X, U, W)
-    @test s.A == A
-    @test s.B == B
-    @test s.c == c
-    @test s.D == D
-    @test statedim(s) == 2
-    @test inputdim(s) == dim(U)
-    @test noisedim(s) == 2 == dim(W)
+    s = NoisyConstrainedAffineControlContinuousSystem(A, B, C, D, X, U, W)
+    @test state_matrix(s) == A
+    @test input_matrix(s) == B
+    @test affine_term(s) == C
+    @test noise_matrix(s) == D
+    @test statedim(s) == sd
+    @test inputdim(s) == id
+    @test noisedim(s) == nd
     @test stateset(s) == X
     @test inputset(s) == U
     @test noiseset(s) == W
@@ -492,22 +563,23 @@ end
         @test isnoisy(s) && iscontrolled(s) && isconstrained(s)
     end
     # Scalar System
-    a = 1.; b = 2.; c = 0.1; d = 3.; X = 1; U = 2; W = 3
-    A = [a][:,:]; B = [b][:,:]; C = [c]; D = [d][:,:]
-    scalar_sys = NoisyConstrainedAffineControlContinuousSystem(a, b, c, d, X, U, W)
-    @test scalar_sys == NoisyConstrainedAffineControlContinuousSystem(A, B, C, D, X, U, W)
+    scalar_sys = NoisyConstrainedAffineControlContinuousSystem(a, b, c, d, Xs, Us, Ws)
+    @test scalar_sys == NoisyConstrainedAffineControlContinuousSystem(As, Bs, Cs, Ds, Xs, Us, Ws)
 end
 
 @testset "Noisy continuous control black-box system" begin
-    n = 2
-    m = 1
-    l = 2
-    f(x,u,w) = ones(n,n)*x + ones(n,m)*u + ones(n,l)*w
-    s = NoisyBlackBoxControlContinuousSystem(f, n, m, l)
-    @test s.f == f
-    @test statedim(s) == n
-    @test inputdim(s) == m
-    @test noisedim(s) == l
+    s = NoisyBlackBoxControlContinuousSystem(add_one, sd, id, nd)
+    @test state_matrix(s) == nothing
+    @test input_matrix(s) == nothing
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == nothing
+    @test s.f(state, input, noise) ≈ stateInputNoisePlusOne
+    @test statedim(s) == sd
+    @test inputdim(s) == id
+    @test noisedim(s) == nd
+    @test stateset(s) == nothing
+    @test inputset(s) == nothing
+    @test noiseset(s) == nothing
     for s = [s, typeof(s)]
         @test !islinear(s) && !isaffine(s) && !ispolynomial(s) && isblackbox(s)
         @test isnoisy(s) && iscontrolled(s) && !isconstrained(s)
@@ -515,18 +587,15 @@ end
 end
 
 @testset "Noisy Continuous constrained control blackbox system" begin
-    n = 2
-    m = 1
-    l = 2
-    f(x,u,w) = ones(n,n)*x + ones(n,m)*u + ones(n,l)*w
-    X = BallInf(zeros(n), 1.0)
-    U =  BallInf(zeros(m), 1.0)
-    W =  BallInf(zeros(l), 1.0)
-    s = NoisyConstrainedBlackBoxControlContinuousSystem(f, n, m, l, X, U, W)
-    @test s.f == f
-    @test statedim(s) == n
-    @test inputdim(s) == dim(U)
-    @test noisedim(s) == l == dim(W)
+    s = NoisyConstrainedBlackBoxControlContinuousSystem(add_one, sd, id, nd, X, U, W)
+    @test state_matrix(s) == nothing
+    @test input_matrix(s) == nothing
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == nothing
+    @test s.f(state, input, noise) ≈ stateInputNoisePlusOne
+    @test statedim(s) == sd
+    @test inputdim(s) == id
+    @test noisedim(s) == nd
     @test stateset(s) == X
     @test inputset(s) == U
     @test noiseset(s) == W

--- a/test/discrete.jl
+++ b/test/discrete.jl
@@ -1,191 +1,255 @@
+# linear systems
+E = [0. 1; 1 0]
+A = [1. 1; 1 -1]
+B = Matrix([0.5 1.5]')
+C = [1.; 1.]
+D = [1. 2; 0 1]
+X = Line([1., -1], 0.) # line x = y
+U = Interval(0.9, 1.1)
+W = BallInf(zeros(2), 2.0)
+sd = 2
+id = 1
+nd = 2
+
+# polynomial system
+@polyvar x y
+p = 2x^2 - 3x + y
+sdp = 2
+
+# blackbox system
+add_one(x) = x .+ 1
+add_one(x, u) = x .+ 1 .+ u
+add_one(x, u, w) = x .+ 1 .+ u .+ w
+state = [1.0; 2.0]
+input = 1
+noise = [3.0; 1.0]
+statePlusOne = add_one(state)
+stateInputPlusOne = add_one(state, input)
+stateInputNoisePlusOne = add_one(state, input, noise)
+
+# Scalar System
+a = 1.; b = 2.; c = 0.1; d = 3.; Xs = 1; Us = 2; Ws = 3; e = 2.;
+As = [a][:,:]; Bs = [b][:,:]; Cs = [c]; Ds = [d][:,:]; Es = [e][:,:]
+
 @testset "Discrete identity system" begin
-    for sd in 1:3
-        s = DiscreteIdentitySystem(sd)
-        @test statedim(s) == sd
-        @test inputdim(s) == 0
-        @test noisedim(s) == 0
-        for s = [s, typeof(s)]
-            @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
-            @test !isnoisy(s) && !iscontrolled(s) && !isconstrained(s)
-        end
+    s = DiscreteIdentitySystem(sd)
+    @test state_matrix(s) == I(sd)
+    @test input_matrix(s) == nothing
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == nothing
+    @test statedim(s) == sd
+    @test inputdim(s) == 0
+    @test noisedim(s) == 0
+    @test stateset(s) == nothing
+    @test inputset(s) == nothing
+    @test noiseset(s) == nothing
+    for s = [s, typeof(s)]
+        @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
+        @test !isnoisy(s) && !iscontrolled(s) && !isconstrained(s)
     end
 end
 
 @testset "Discrete constrained identity system" begin
-    for sd in 1:3
-        X = Singleton(ones(sd))
-        s = ConstrainedDiscreteIdentitySystem(sd, X)
-        @test statedim(s) == sd
-        @test inputdim(s) == 0
-        @test noisedim(s) == 0
-        @test stateset(s) == X
-        for s = [s, typeof(s)]
-            @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
-            @test !isnoisy(s) && !iscontrolled(s) && isconstrained(s)
-        end
+    s = ConstrainedDiscreteIdentitySystem(sd, X)
+    @test state_matrix(s) == I(sd)
+    @test input_matrix(s) == nothing
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == nothing
+    @test statedim(s) == sd
+    @test inputdim(s) == 0
+    @test noisedim(s) == 0
+    @test stateset(s) == X
+    @test inputset(s) == nothing
+    @test noiseset(s) == nothing
+    for s = [s, typeof(s)]
+        @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
+        @test !isnoisy(s) && !iscontrolled(s) && isconstrained(s)
     end
 end
 
 @testset "Discrete linear system" begin
-    for sd in 1:3
-        s = LinearDiscreteSystem(zeros(sd, sd))
-        @test statedim(s) == sd
-        @test inputdim(s) == 0
-        @test noisedim(s) == 0
-        for s = [s, typeof(s)]
-            @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
-            @test !isnoisy(s) && !iscontrolled(s) && !isconstrained(s)
-        end
+    s = LinearDiscreteSystem(A)
+    @test state_matrix(s) == A
+    @test input_matrix(s) == nothing
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == nothing
+    @test statedim(s) == sd
+    @test inputdim(s) == 0
+    @test noisedim(s) == 0
+    @test stateset(s) == nothing
+    @test inputset(s) == nothing
+    @test noiseset(s) == nothing
+    for s = [s, typeof(s)]
+        @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
+        @test !isnoisy(s) && !iscontrolled(s) && !isconstrained(s)
     end
     # Scalar System
-    a = 1.
-    A = [a][:,:]
     scalar_sys = LinearDiscreteSystem(a)
-    @test scalar_sys == LinearDiscreteSystem(A)
+    @test scalar_sys == LinearDiscreteSystem(As)
 end
 
 @testset "Discrete affine system" begin
-    for sd in 1:3
-        s = AffineDiscreteSystem(zeros(sd, sd), zeros(sd))
-        @test statedim(s) == sd
-        @test inputdim(s) == 0
-        @test noisedim(s) == 0
-        for s = [s, typeof(s)]
-            @test !islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
-            @test !isnoisy(s) && !iscontrolled(s) && !isconstrained(s)
-        end
+    s = AffineDiscreteSystem(A, C)
+    @test state_matrix(s) == A
+    @test input_matrix(s) == nothing
+    @test affine_term(s) == C
+    @test noise_matrix(s) == nothing
+    @test statedim(s) == sd
+    @test inputdim(s) == 0
+    @test noisedim(s) == 0
+    @test stateset(s) == nothing
+    @test inputset(s) == nothing
+    @test noiseset(s) == nothing
+    for s = [s, typeof(s)]
+        @test !islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
+        @test !isnoisy(s) && !iscontrolled(s) && !isconstrained(s)
     end
     # Scalar System
-    a = 1.; c = 0.1
-    A = [a][:,:]; C = [c]
     scalar_sys = AffineDiscreteSystem(a, c)
-    @test scalar_sys == AffineDiscreteSystem(A, C)
+    @test scalar_sys == AffineDiscreteSystem(As, Cs)
 end
 
 @testset "Discrete linear control system" begin
-    for sd in 1:3
-        s = LinearControlDiscreteSystem(zeros(sd, sd), ones(sd, sd))
-        @test statedim(s) == sd
-        @test inputdim(s) == sd
-        @test noisedim(s) == 0
-        for s = [s, typeof(s)]
-            @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
-            @test !isnoisy(s) && iscontrolled(s) && !isconstrained(s)
-        end
+    s = LinearControlDiscreteSystem(A, B)
+    @test state_matrix(s) == A
+    @test input_matrix(s) == B
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == nothing
+    @test statedim(s) == sd
+    @test inputdim(s) == id
+    @test noisedim(s) == 0
+    @test stateset(s) == nothing
+    @test inputset(s) == nothing
+    @test noiseset(s) == nothing
+    for s = [s, typeof(s)]
+        @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
+        @test !isnoisy(s) && iscontrolled(s) && !isconstrained(s)
     end
     # Scalar System
-    a = 1.; b = 2.
-    A = [a][:,:]; B = [b][:,:]
     scalar_sys = LinearControlDiscreteSystem(a, b)
-    @test scalar_sys == LinearControlDiscreteSystem(A, B)
+    @test scalar_sys == LinearControlDiscreteSystem(As, Bs)
 end
 
 @testset "Discrete constrained linear system" begin
-    A = [1. 1; 1 -1]
-    X = Line([1., -1], 0.) # line x = y
     s = ConstrainedLinearDiscreteSystem(A, X)
-    @test statedim(s) == 2
+    @test state_matrix(s) == A
+    @test input_matrix(s) == nothing
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == nothing
+    @test statedim(s) == sd
     @test inputdim(s) == 0
     @test noisedim(s) == 0
     @test stateset(s) == X
+    @test inputset(s) == nothing
+    @test noiseset(s) == nothing
     for s = [s, typeof(s)]
         @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
         @test !isnoisy(s) && !iscontrolled(s) && isconstrained(s)
     end
     # Scalar System
-    a = 1.; X = 1
-    A = [a][:,:]
-    scalar_sys = ConstrainedLinearDiscreteSystem(a, X)
-    @test scalar_sys == ConstrainedLinearDiscreteSystem(A, X)
+    scalar_sys = ConstrainedLinearDiscreteSystem(a, Xs)
+    @test scalar_sys == ConstrainedLinearDiscreteSystem(As, Xs)
 end
 
 @testset "Discrete constrained affine system" begin
-    A = [1. 1; 1 -1]
-    c = [1.; 1.]
-    X = Line([1., -1], 0.) # line x = y
-    s = ConstrainedAffineDiscreteSystem(A, c, X)
-    @test statedim(s) == 2
+    s = ConstrainedAffineDiscreteSystem(A, C, X)
+    @test state_matrix(s) == A
+    @test input_matrix(s) == nothing
+    @test affine_term(s) == C
+    @test noise_matrix(s) == nothing
+    @test statedim(s) == sd
     @test inputdim(s) == 0
     @test noisedim(s) == 0
     @test stateset(s) == X
+    @test inputset(s) == nothing
+    @test noiseset(s) == nothing
     for s = [s, typeof(s)]
         @test !islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
         @test !isnoisy(s) && !iscontrolled(s) && isconstrained(s)
     end
     # Scalar System
-    a = 1.; c = 0.1; X = 1
-    A = [a][:,:]; C = [c]
-    scalar_sys = ConstrainedAffineDiscreteSystem(a, c, X)
-    @test scalar_sys == ConstrainedAffineDiscreteSystem(A, C, X)
+    scalar_sys = ConstrainedAffineDiscreteSystem(a, c, Xs)
+    @test scalar_sys == ConstrainedAffineDiscreteSystem(As, Cs, Xs)
 end
 
 @testset "Discrete constrained linear control system" begin
-    A = [1. 1; 1 -1]
-    B = Matrix([0.5 1.5]')
-    X = Line([1., -1], 0.)
-    U = Interval(0.9, 1.1)
     s = ConstrainedLinearControlDiscreteSystem(A, B, X, U)
-    @test statedim(s) == 2
-    @test inputdim(s) == 1
+    @test state_matrix(s) == A
+    @test input_matrix(s) == B
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == nothing
+    @test statedim(s) == sd
+    @test inputdim(s) == id
     @test noisedim(s) == 0
     @test stateset(s) == X
     @test inputset(s) == U
+    @test noiseset(s) == nothing
     for s = [s, typeof(s)]
         @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
         @test !isnoisy(s) && iscontrolled(s) && isconstrained(s)
     end
     # Scalar System
-    a = 1.; b = 2.; X = 1; U = 2
-    A = [a][:,:]; B = [b][:,:]
-    scalar_sys = ConstrainedLinearControlDiscreteSystem(a, b, X, U)
-    @test scalar_sys == ConstrainedLinearControlDiscreteSystem(A, B, X, U)
+    scalar_sys = ConstrainedLinearControlDiscreteSystem(a, b, Xs, Us)
+    @test scalar_sys == ConstrainedLinearControlDiscreteSystem(As, Bs, Xs, Us)
 end
 
 @testset "Discrete linear algebraic system" begin
-    for sd in 1:3
-        s = LinearAlgebraicDiscreteSystem(zeros(sd, sd), zeros(sd, sd))
-        @test statedim(s) == sd
-        @test inputdim(s) == 0
-        @test noisedim(s) == 0
-        for s = [s, typeof(s)]
-            @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
-            @test !isnoisy(s) && !iscontrolled(s) && !isconstrained(s)
-        end
+    s = LinearAlgebraicDiscreteSystem(A, E)
+    @test state_matrix(s) == A
+    @test input_matrix(s) == nothing
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == nothing
+    @test s.E == E
+    @test statedim(s) == sd
+    @test inputdim(s) == 0
+    @test noisedim(s) == 0
+    @test stateset(s) == nothing
+    @test inputset(s) == nothing
+    @test noiseset(s) == nothing
+    for s = [s, typeof(s)]
+        @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
+        @test !isnoisy(s) && !iscontrolled(s) && !isconstrained(s)
     end
     # Scalar System
-    a = 1.; e = 2.;
-    A = [a][:,:]; E = [e][:,:]
     scalar_sys = LinearAlgebraicDiscreteSystem(a, e)
-    @test scalar_sys == LinearAlgebraicDiscreteSystem(A, E)
+    @test scalar_sys == LinearAlgebraicDiscreteSystem(As, Es)
 end
 
 @testset "Discrete constrained linear algebraic system" begin
-    A = [1. 1; 1 -1]
-    E = [0. 1; 1 0]
-    X = LinearConstraint([0, -1.], 0.) # the set y ≥ 0
     s = ConstrainedLinearAlgebraicDiscreteSystem(A, E, X)
-    @test statedim(s) == 2
+    @test state_matrix(s) == A
+    @test input_matrix(s) == nothing
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == nothing
+    @test s.E == E
+    @test statedim(s) == sd
     @test inputdim(s) == 0
     @test noisedim(s) == 0
     @test stateset(s) == X
+    @test inputset(s) == nothing
+    @test noiseset(s) == nothing
     for s = [s, typeof(s)]
         @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
         @test !isnoisy(s) && !iscontrolled(s) && isconstrained(s)
     end
     # Scalar System
-    a = 1.; e = 2.; X = 1
-    A = [a][:,:]; E = [e][:,:]
-    scalar_sys = ConstrainedLinearAlgebraicDiscreteSystem(a, e, X)
-    @test scalar_sys == ConstrainedLinearAlgebraicDiscreteSystem(A, E, X)
+    scalar_sys = ConstrainedLinearAlgebraicDiscreteSystem(a, e, Xs)
+    @test scalar_sys == ConstrainedLinearAlgebraicDiscreteSystem(As, Es, Xs)
 end
 
 @testset "Polynomial system in discrete time" begin
-    @polyvar x y
-    p = 2x^2 - 3x + y
     s = PolynomialDiscreteSystem(p)
-    @test statedim(s) == 2
+    @test state_matrix(s) == nothing
+    @test input_matrix(s) == nothing
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == nothing
+    # @test s.p == p
+    @test statedim(s) == sdp
     @test inputdim(s) == 0
     @test noisedim(s) == 0
+    @test stateset(s) == nothing
+    @test inputset(s) == nothing
+    @test noiseset(s) == nothing
     for s = [s, typeof(s)]
         @test !islinear(s) && !isaffine(s) && ispolynomial(s) && !isblackbox(s)
         @test !isnoisy(s) && !iscontrolled(s) && !isconstrained(s)
@@ -193,14 +257,18 @@ end
 end
 
 @testset "Polynomial system in discrete time with state constraints" begin
-    @polyvar x y
-    p = 2x^2 - 3x + y
-    X = BallInf(zeros(2), 0.1)
     s = ConstrainedPolynomialDiscreteSystem(p, X)
-    @test statedim(s) == 2
+    @test state_matrix(s) == nothing
+    @test input_matrix(s) == nothing
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == nothing
+    # @test s.p == p
+    @test statedim(s) == sdp
     @test inputdim(s) == 0
     @test noisedim(s) == 0
-    @test dim(stateset(s)) == dim(X)
+    @test stateset(s) == X
+    @test inputset(s) == nothing
+    @test noiseset(s) == nothing
     for s = [s, typeof(s)]
         @test !islinear(s) && !isaffine(s) && ispolynomial(s) && !isblackbox(s)
         @test !isnoisy(s) && !iscontrolled(s) && isconstrained(s)
@@ -208,10 +276,18 @@ end
 end
 
 @testset "Implicit discrete system" begin
-    add_one(x) = x + 1
-    s = BlackBoxDiscreteSystem(add_one, 1)
-    x = 1.0
-    @test s.f(x) ≈ 2.0
+    s = BlackBoxDiscreteSystem(add_one, sd)
+    @test state_matrix(s) == nothing
+    @test input_matrix(s) == nothing
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == nothing
+    @test s.f(state) ≈ statePlusOne
+    @test statedim(s) == sd
+    @test inputdim(s) == 0
+    @test noisedim(s) == 0
+    @test stateset(s) == nothing
+    @test inputset(s) == nothing
+    @test noiseset(s) == nothing
     for s = [s, typeof(s)]
         @test !islinear(s) && !isaffine(s) && !ispolynomial(s) && isblackbox(s)
         @test !isnoisy(s) && !iscontrolled(s) && !isconstrained(s)
@@ -219,10 +295,18 @@ end
 end
 
 @testset "Discrete control black-box system" begin
-    add_one(x) = x + 1
-    s = BlackBoxControlDiscreteSystem(add_one, 2, 1)
-    @test statedim(s) == 2
-    @test inputdim(s) == 1
+    s = BlackBoxControlDiscreteSystem(add_one, sd, id)
+    @test state_matrix(s) == nothing
+    @test input_matrix(s) == nothing
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == nothing
+    @test s.f(state, input) ≈ stateInputPlusOne
+    @test statedim(s) == sd
+    @test inputdim(s) == id
+    @test noisedim(s) == 0
+    @test stateset(s) == nothing
+    @test inputset(s) == nothing
+    @test noiseset(s) == nothing
     for s = [s, typeof(s)]
         @test !islinear(s) && !isaffine(s) && !ispolynomial(s) && isblackbox(s)
         @test !isnoisy(s) && iscontrolled(s) && !isconstrained(s)
@@ -234,85 +318,77 @@ end
 # ==============
 
 @testset "Noisy Discrete linear system" begin
-    A = [1. 1; 1 -1]
-    D = [1. 2; 0 1]
     s = NoisyLinearDiscreteSystem(A, D)
-    @test s.A == A
-    @test s.D == D
-    @test statedim(s) == 2
+    @test state_matrix(s) == A
+    @test input_matrix(s) == nothing
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == D
+    @test statedim(s) == sd
     @test inputdim(s) == 0
-    @test noisedim(s) == 2
+    @test noisedim(s) == nd
+    @test stateset(s) == nothing
+    @test inputset(s) == nothing
+    @test noiseset(s) == nothing
     for s = [s, typeof(s)]
         @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
         @test isnoisy(s) && !iscontrolled(s) && !isconstrained(s)
     end
     # Scalar System
-    a = 1.; d = 3.
-    A = [a][:,:]; D = [d][:,:]
     scalar_sys = NoisyLinearDiscreteSystem(a, d)
-    @test scalar_sys == NoisyLinearDiscreteSystem(A, D)
+    @test scalar_sys == NoisyLinearDiscreteSystem(As, Ds)
 end
 
 @testset "Noisy Discrete constrained linear system" begin
-    A = [1. 1; 1 -1]
-    D = [1. 2; 0 1]
-    X = Line([1., -1], 0.) # line x = y
-    W = BallInf(zeros(2), 2.0)
     s = NoisyConstrainedLinearDiscreteSystem(A, D, X, W)
-    @test s.A == A
-    @test s.D == D
-    @test statedim(s) == 2
+    @test state_matrix(s) == A
+    @test input_matrix(s) == nothing
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == D
+    @test statedim(s) == sd
     @test inputdim(s) == 0
-    @test noisedim(s) == 2 == dim(W)
+    @test noisedim(s) == nd
     @test stateset(s) == X
+    @test inputset(s) == nothing
     @test noiseset(s) == W
     for s = [s, typeof(s)]
         @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
         @test isnoisy(s) && !iscontrolled(s) && isconstrained(s)
     end
     # Scalar System
-    a = 1.; d = 3.; X = 1; W = 3
-    A = [a][:,:]; D = [d][:,:]
-    scalar_sys = NoisyConstrainedLinearDiscreteSystem(a, d, X, W)
-    @test scalar_sys == NoisyConstrainedLinearDiscreteSystem(A, D, X, W)
+    scalar_sys = NoisyConstrainedLinearDiscreteSystem(a, d, Xs, Ws)
+    @test scalar_sys == NoisyConstrainedLinearDiscreteSystem(As, Ds, Xs, Ws)
 end
 
 @testset "Noisy discrete control linear system" begin
-    A = [1. 1; 1 -1]
-    B = Matrix([0.5 1.5]')
-    D = [1. 2; 0 1]
     s = NoisyLinearControlDiscreteSystem(A, B, D)
-    @test s.A == A
-    @test s.B == B
-    @test s.D == D
-    @test statedim(s) == 2
-    @test inputdim(s) == 1
-    @test noisedim(s) == 2
+    @test state_matrix(s) == A
+    @test input_matrix(s) == B
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == D
+    @test statedim(s) == sd
+    @test inputdim(s) == id
+    @test noisedim(s) == nd
+    @test stateset(s) == nothing
+    @test inputset(s) == nothing
+    @test noiseset(s) == nothing
     for s = [s, typeof(s)]
         @test islinear(s) && isaffine(s) && !ispolynomial(s) && !isblackbox(s)
         @test isnoisy(s) && iscontrolled(s) && !isconstrained(s)
     end
     # Scalar System
-    a = 1.; b = 2.; d = 3.
-    A = [a][:,:]; B = [b][:,:]; D = [d][:,:]
     scalar_sys = NoisyLinearControlDiscreteSystem(a, b, d)
-    @test scalar_sys == NoisyLinearControlDiscreteSystem(A, B, D)
+    @test scalar_sys == NoisyLinearControlDiscreteSystem(As, Bs, Ds)
 end
 
 @testset "Noisy Discrete constrained control linear system" begin
-    A = [1. 1; 1 -1]
-    B = Matrix([0.5 1.5]')
-    D = [1. 2; 0 1]
-    X = Line([1., -1], 0.) # line x = y
-    U = Hyperrectangle(low=[0.9], high=[1.1])
-    W = BallInf(zeros(2), 2.0)
     s = NoisyConstrainedLinearControlDiscreteSystem(A, B, D, X, U, W)
-    @test s.A == A
-    @test s.B == B
-    @test s.D == D
-    @test statedim(s) == 2
-    @test inputdim(s) == dim(U)
-    @test noisedim(s) == 2 == dim(W)
+    @test state_matrix(s) == A
+    @test input_matrix(s) == B
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == D
+    @test statedim(s) == sd
+    @test inputdim(s) == id
+    @test noisedim(s) == nd
     @test stateset(s) == X
     @test inputset(s) == U
     @test noiseset(s) == W
@@ -321,52 +397,40 @@ end
         @test isnoisy(s) && iscontrolled(s) && isconstrained(s)
     end
     # Scalar System
-    a = 1.; b = 2.; d = 3.; X = 1; U = 2; W = 3
-    A = [a][:,:]; B = [b][:,:]; D = [d][:,:]
-    scalar_sys = NoisyConstrainedLinearControlDiscreteSystem(a, b, d, X, U, W)
-    @test scalar_sys == NoisyConstrainedLinearControlDiscreteSystem(A, B, D, X, U, W)
+    scalar_sys = NoisyConstrainedLinearControlDiscreteSystem(a, b, d, Xs, Us, Ws)
+    @test scalar_sys == NoisyConstrainedLinearControlDiscreteSystem(As, Bs, Ds, Xs, Us, Ws)
 end
 
 @testset "Noisy discrete control affine system" begin
-    A = [1. 1; 1 -1]
-    B = Matrix([0.5 1.5]')
-    c = [1.0, 0.5]
-    D = [1. 2; 0 1]
-    s = NoisyAffineControlDiscreteSystem(A, B, c, D)
-    @test s.A == A
-    @test s.B == B
-    @test s.c == c
-    @test s.D == D
-    @test statedim(s) == 2
-    @test inputdim(s) == 1
-    @test noisedim(s) == 2
+    s = NoisyAffineControlDiscreteSystem(A, B, C, D)
+    @test state_matrix(s) == A
+    @test input_matrix(s) == B
+    @test affine_term(s) == C
+    @test noise_matrix(s) == D
+    @test statedim(s) == sd
+    @test inputdim(s) == id
+    @test noisedim(s) == nd
+    @test stateset(s) == nothing
+    @test inputset(s) == nothing
+    @test noiseset(s) == nothing
     for s = [s, typeof(s)]
         @test isaffine(s) && !islinear(s) && !ispolynomial(s) && !isblackbox(s)
         @test isnoisy(s) && iscontrolled(s) && !isconstrained(s)
     end
     # Scalar System
-    a = 1.; b = 2.; c = 0.1; d = 3.; X = 1; U = 2; W = 3
-    A = [a][:,:]; B = [b][:,:]; C = [c]; D = [d][:,:]
     scalar_sys = NoisyAffineControlDiscreteSystem(a, b, c, d)
-    @test scalar_sys == NoisyAffineControlDiscreteSystem(A, B, C, D)
+    @test scalar_sys == NoisyAffineControlDiscreteSystem(As, Bs, Cs, Ds)
 end
 
 @testset "Noisy Discrete constrained control affine system" begin
-    A = [1. 1; 1 -1]
-    B = Matrix([0.5 1.5]')
-    c = [1.0, 0.5]
-    D = [1. 2; 0 1]
-    X = Line([1., -1], 0.) # line x = y
-    U = Hyperrectangle(low=[0.9], high=[1.1])
-    W = BallInf(zeros(2), 2.0)
-    s = NoisyConstrainedAffineControlDiscreteSystem(A, B, c, D, X, U, W)
-    @test s.A == A
-    @test s.B == B
-    @test s.c == c
-    @test s.D == D
-    @test statedim(s) == 2
-    @test inputdim(s) == dim(U)
-    @test noisedim(s) == 2 == dim(W)
+    s = NoisyConstrainedAffineControlDiscreteSystem(A, B, C, D, X, U, W)
+    @test state_matrix(s) == A
+    @test input_matrix(s) == B
+    @test affine_term(s) == C
+    @test noise_matrix(s) == D
+    @test statedim(s) == sd
+    @test inputdim(s) == id
+    @test noisedim(s) == nd
     @test stateset(s) == X
     @test inputset(s) == U
     @test noiseset(s) == W
@@ -375,22 +439,23 @@ end
         @test isnoisy(s) && iscontrolled(s) && isconstrained(s)
     end
     # Scalar System
-    a = 1.; b = 2.; c = 0.1; d = 3.; X = 1; U = 2; W = 3
-    A = [a][:,:]; B = [b][:,:]; C = [c]; D = [d][:,:]
-    scalar_sys = NoisyConstrainedAffineControlDiscreteSystem(a, b, c, d, X, U, W)
-    @test scalar_sys == NoisyConstrainedAffineControlDiscreteSystem(A, B, C, D, X, U, W)
+    scalar_sys = NoisyConstrainedAffineControlDiscreteSystem(a, b, c, d, Xs, Us, Ws)
+    @test scalar_sys == NoisyConstrainedAffineControlDiscreteSystem(As, Bs, Cs, Ds, Xs, Us, Ws)
 end
 
 @testset "Noisy discrete control black-box system" begin
-    n = 2
-    m = 1
-    l = 2
-    f(x,u,w) = ones(n,n)*x + ones(n,m)*u + ones(n,l)*w
-    s = NoisyBlackBoxControlDiscreteSystem(f, n, m, l)
-    @test s.f == f
-    @test statedim(s) == n
-    @test inputdim(s) == m
-    @test noisedim(s) == l
+    s = NoisyBlackBoxControlDiscreteSystem(add_one, sd, id, nd)
+    @test state_matrix(s) == nothing
+    @test input_matrix(s) == nothing
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == nothing
+    @test s.f(state, input, noise) ≈ stateInputNoisePlusOne
+    @test statedim(s) == sd
+    @test inputdim(s) == id
+    @test noisedim(s) == nd
+    @test stateset(s) == nothing
+    @test inputset(s) == nothing
+    @test noiseset(s) == nothing
     for s = [s, typeof(s)]
         @test !islinear(s) && !isaffine(s) && !ispolynomial(s) && isblackbox(s)
         @test isnoisy(s) && iscontrolled(s) && !isconstrained(s)
@@ -398,18 +463,15 @@ end
 end
 
 @testset "Noisy Discrete constrained control blackbox system" begin
-    n = 2
-    m = 1
-    l = 2
-    f(x,u,w) = ones(n,n)*x + ones(n,m)*u + ones(n,l)*w
-    X = BallInf(zeros(n), 1.0)
-    U =  BallInf(zeros(m), 1.0)
-    W =  BallInf(zeros(l), 1.0)
-    s = NoisyConstrainedBlackBoxControlDiscreteSystem(f, n, m, l, X, U, W)
-    @test s.f == f
-    @test statedim(s) == n
-    @test inputdim(s) == m == dim(U)
-    @test noisedim(s) == l == dim(W)
+    s = NoisyConstrainedBlackBoxControlDiscreteSystem(add_one, sd, id, nd, X, U, W)
+    @test state_matrix(s) == nothing
+    @test input_matrix(s) == nothing
+    @test affine_term(s) == nothing
+    @test noise_matrix(s) == nothing
+    @test s.f(state, input, noise) ≈ stateInputNoisePlusOne
+    @test statedim(s) == sd
+    @test inputdim(s) == id
+    @test noisedim(s) == nd
     @test stateset(s) == X
     @test inputset(s) == U
     @test noiseset(s) == W
@@ -421,9 +483,6 @@ end
 
 
 @testset "Constant input in a discrete constrained linear control system" begin
-    A = [1. 1; 1 -1]
-    B = Matrix([0.5 1.5]')
-    X = Line([1., -1], 0.)
     U = ConstantInput(Hyperrectangle(low=[0.9], high=[1.1]))
     s = ConstrainedLinearControlDiscreteSystem(A, B, X, U)
     s = ConstrainedLinearControlDiscreteSystem(A, B, X, U)
@@ -436,9 +495,6 @@ end
 
 
 @testset "Varying input in a discrete constrained linear control system" begin
-    A = [1. 1; 1 -1]
-    B = Matrix([0.5 1.5]')
-    X = Line([1., -1], 0.)
     U = VaryingInput([Hyperrectangle(low=[0.9], high=[1.1]),
                       Hyperrectangle(low=[0.99], high=[1.0])])
     s = ConstrainedLinearControlDiscreteSystem(A, B, X, U)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,16 +11,16 @@ const SECOND_ORDER_CTYPES = [SecondOrderAffineContinuousSystem,
                              SecondOrderConstrainedLinearControlContinuousSystem,
                              SecondOrderLinearContinuousSystem]
 
-include("continuous.jl")
-include("discrete.jl")
-include("identity.jl")
-include("inputs.jl")
-include("maps.jl")
-include("outputs.jl")
-include("macros.jl")
-include("successor.jl")
-include("vector_field.jl")
-include("utilities.jl")
-include("discretize.jl")
-include("@system.jl")
-include("@ivp.jl")
+@testset "Utilities" begin include("utilities.jl") end
+@testset "Continuous Systems" begin include("continuous.jl") end
+@testset "Discrete Systems" begin include("discrete.jl") end
+@testset "Identity Multiple" begin include("identity.jl") end
+@testset "Inputs" begin include("inputs.jl") end
+@testset "Maps" begin include("maps.jl") end
+@testset "Outputs" begin include("outputs.jl") end
+@testset "Succesor of discrete system" begin include("successor.jl") end
+@testset "Vector field of continuous system" begin include("vector_field.jl") end
+@testset "Discretize continuous system" begin include("discretize.jl") end
+@testset "@sytem macro" begin include("@system.jl") end
+@testset "@ivp macro" begin include("@ivp.jl") end
+@testset "Other macros" begin include("macros.jl") end


### PR DESCRIPTION
closes #200 

Following the proposal of @schillic, I implemented a default case for all getters that returns `nothing` if the method is not implemented. Additionally, I tried to give the unit tests for discrete and continuous systems more structure (which resulted in a large PR...sorry 😁)

As a by-product, I also added the supertype `AbstractSystem` to the `SystemWithOutput` type.