### PR TITLE
Plot recipe for VectorField

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,9 @@ branches:
   - /^testing-.*$/  # testing branches
   - /^v[0-9]+\.[0-9]+\.[0-9]+$/  # version tags
 
-matrix:
-  fast_finish: true
-  allow_failures:
-    - julia: nightly
+script:
+ - julia --project --color=yes --check-bounds=yes -e 'using Pkg; ; if VERSION >= v"1.1.0-rc1"; Pkg.build(verbose=true); else Pkg.add(Pkg.PackageSpec("RecipesBase", v"0.7")); Pkg.build(); end; Pkg.test(coverage=true)'
+jobs:
   include:
     - stage: "Documentation"
       julia: 1.4

--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MultivariatePolynomials = "102ac46a-7ee4-5c85-9060-abc95bfdeaa3"
+RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
@@ -15,6 +16,7 @@ julia = "1"
 Espresso = "0.6.0"
 MacroTools = "0.5"
 MultivariatePolynomials = "0.3"
+RecipesBase = "0.6, 0.7, 0.8, 1.0, 1.1"
 
 [extras]
 LazySets = "b4f0291d-fe17-52bc-9479-3d1a343d9043"

--- a/src/MathematicalSystems.jl
+++ b/src/MathematicalSystems.jl
@@ -3,6 +3,7 @@ module MathematicalSystems
 
 using LinearAlgebra, SparseArrays
 using LinearAlgebra: checksquare
+using RecipesBase
 
 #=======================
 Identity operator


### PR DESCRIPTION
This is open for discussion.

Usage:
```julia
julia> f(x) = [2*x[2], -x[1]]
julia> V = MathematicalSystems.VectorField(f)
julia> plot(V)  # uses a default grid of 20x20 points for the range [-3, 3] x [-3, 3]
```
![1](https://user-images.githubusercontent.com/9656686/100524361-d6f3a500-31b7-11eb-93e8-f53e45af05e2.png)
```julia
julia> plot(V, x=range(-3, stop=3, length=11), y=range(-3, stop=3, length=11))  # pass a custom grid
```
![2](https://user-images.githubusercontent.com/9656686/100524364-d955ff00-31b7-11eb-9867-ae981594a2d1.png)

EDIT: For reference, this is the result of the default quiver plot (note that here the function `f` needs to take two arguments and in my approach it needs to take a vector):

```julia
f(x, y) = [2*x, -y]
x = range(-3, stop=3, length=21)
y = range(-3, stop=3, length=21)
x_full = [xi for xi in x for yj in y]
y_full = [yj for xi in x for yj in y]
quiver(x_full, y_full, quiver=f)
```
![3](https://user-images.githubusercontent.com/9656686/100524549-664d8800-31b9-11eb-9afb-fa15fe0f3b04.png)