### PR TITLE
Fix affine system corner case

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -280,14 +280,20 @@ function _parse_system(exprs::NTuple{N, Expr}) where {N}
                 dynamic_equation = stripped
                 state_var = subject
                 AT = abstract_system_type
-                # if the system has the structure x_ = A_*x_ + B_*u_ ,
-                # handle u_ as input variable
+                # if the stripped system has the structure x_ = A_*x_ + B_*u_ or
+                # one of the other pattern, handle u_ as input variable
                 if @capture(stripped, (x_ = A_*x_ + B_*u_) |
                                       (x_ = x_ + B_*u_) |
                                       (x_ = A_*x_ + B_*u_ + c_) |
                                       (x_ = x_ + B_*u_ + c_) |
                                       (x_ = f_(x_, u_)) )
-                    input_var = u
+                    if (f == :+) || (f == :-) || (f == :*)
+                        # pattern x_ = f_(x_, u_) also catches the cases:
+                        # x_ = x_ + u_, x_ = x_ - u_ and x_ = x_*u_
+                        # where u_ doesn't necessarily needs to be the input
+                    else
+                        input_var = u
+                    end
                 end
 
             elseif @capture(ex, (dim = (f_dims_)) | (dims = (f_dims_)))
@@ -407,13 +413,11 @@ function extract_dyn_equation_parameters(equation, state, input, noise, dim, AT)
         rhs = rhscode
     end
 
-    # if rhs is a sum, =>  affine system which is controlled, noisy or both
+    # if rhs is a sum =>  affine system which is controlled, noisy or both
     if @capture(rhs, A_ + B__)
         # parse summands of rhs and add * if needed
         summands = add_asterisk.([A, B...], Ref(state), Ref(input), Ref(noise))
         push!(rhs_params, extract_sum(summands, state, input, noise)...)
-
-    # If rhs is function call => black-box system
     elseif @capture(rhs, f_(a__))  && f != :(*) && f != :(-)
         # the dimension argument needs to be a iterable
         (dim == nothing) && throw(ArgumentError("for a blackbox system, the dimension has to be defined"))

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -418,7 +418,7 @@ function extract_dyn_equation_parameters(equation, state, input, noise, dim, AT)
         # parse summands of rhs and add * if needed
         summands = add_asterisk.([A, B...], Ref(state), Ref(input), Ref(noise))
         push!(rhs_params, extract_sum(summands, state, input, noise)...)
-    # if rhs is a function call except `*` or `-`
+    # if rhs is a function call except `*` or `-` => black-box system
     elseif @capture(rhs, f_(a__)) && f != :(*) && f != :(-)
         # the dimension argument needs to be a iterable
         (dim == nothing) && throw(ArgumentError("for a blackbox system, the dimension has to be defined"))

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -413,12 +413,13 @@ function extract_dyn_equation_parameters(equation, state, input, noise, dim, AT)
         rhs = rhscode
     end
 
-    # if rhs is a sum =>  affine system which is controlled, noisy or both
+    # if rhs is parsed as addition => affine system which is controlled, noisy or both
     if @capture(rhs, A_ + B__)
         # parse summands of rhs and add * if needed
         summands = add_asterisk.([A, B...], Ref(state), Ref(input), Ref(noise))
         push!(rhs_params, extract_sum(summands, state, input, noise)...)
-    elseif @capture(rhs, f_(a__))  && f != :(*) && f != :(-)
+    # if rhs is a function call except `*` or `-`
+    elseif @capture(rhs, f_(a__)) && f != :(*) && f != :(-)
         # the dimension argument needs to be a iterable
         (dim == nothing) && throw(ArgumentError("for a blackbox system, the dimension has to be defined"))
         dim_vec = [dim...]

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -281,7 +281,7 @@ function _parse_system(exprs::NTuple{N, Expr}) where {N}
                 state_var = subject
                 AT = abstract_system_type
                 # if the stripped system has the structure x_ = A_*x_ + B_*u_ or
-                # one of the other pattern, handle u_ as input variable
+                # one of the other patterns, handle u_ as input variable
                 if @capture(stripped, (x_ = A_*x_ + B_*u_) |
                                       (x_ = x_ + B_*u_) |
                                       (x_ = A_*x_ + B_*u_ + c_) |
@@ -290,7 +290,7 @@ function _parse_system(exprs::NTuple{N, Expr}) where {N}
                     if (f == :+) || (f == :-) || (f == :*)
                         # pattern x_ = f_(x_, u_) also catches the cases:
                         # x_ = x_ + u_, x_ = x_ - u_ and x_ = x_*u_
-                        # where u_ doesn't necessarily needs to be the input
+                        # where u_ doesn't necessarily need to be the input
                     else
                         input_var = u
                     end

--- a/test/@system.jl
+++ b/test/@system.jl
@@ -139,7 +139,9 @@ end
 end
 
 @testset "@system for affine continuous systems" begin
-    @test @system(x' = A*x  + c) == AffineContinuousSystem(A, c)
+    @test @system(x' = x + [1.0]) == AffineContinuousSystem(I(1), [1.0])
+    @test @system(x' = x + [1.0, 2.0], dim:(2)) == AffineContinuousSystem(I(1), [1.0, 2.0])
+    @test @system(x' = A*x + c) == AffineContinuousSystem(A, c)
     sys =  @system(z_1' = A*z_1 + B*v_1 + c1, z_1 ∈ X, v_1 ∈ U1, input:v_1)
     @test sys == ConstrainedAffineControlContinuousSystem(A, B, c1, X, U1)
     @test_throws ArgumentError @system(x' = Ax + Bu + c) # not a system type


### PR DESCRIPTION
closes #221 

Adding the condition that the stripped system is only parsed as a black-box system, if `f` is not an addition, multiplication or subtraction.