### PR TITLE
Fix normalization in vector-field plot

### DIFF
--- a/src/vector_field.jl
+++ b/src/vector_field.jl
@@ -198,9 +198,10 @@ function _position_value_list(V::VectorField, grid, dimx, dimy)
         step_y = (maximum(Y) - minimum(Y)) / length(Y)
         max_entry_x = max_entry / step_x
         max_entry_y = max_entry / step_y
+        max_entry = max(max_entry_x, max_entry_y)
         for k in 1:m
-            vx[k] /= max_entry_x
-            vy[k] /= max_entry_y
+            vx[k] /= max_entry
+            vy[k] /= max_entry
         end
     end
 


### PR DESCRIPTION
Normalization should not be applied individually for each dimension. This came up when plotting the bouncing ball, which has fast and slow variables. The simulation shows that the old arrows were not correct.

old:

![old](https://user-images.githubusercontent.com/9656686/108477564-aa6d9780-7293-11eb-9608-79862e325066.png)

new:

![new](https://user-images.githubusercontent.com/9656686/108477577-af324b80-7293-11eb-87dd-8907b0eb80cf.png)
