### PR TITLE
Rename I -> Id and change signature

### DIFF
--- a/docs/src/lib/types.md
+++ b/docs/src/lib/types.md
@@ -120,6 +120,7 @@ EulerDiscretization
 
 ```@docs
 IdentityMultiple
+Id
 ```
 
 ## Initial Value Problems

--- a/src/MathematicalSystems.jl
+++ b/src/MathematicalSystems.jl
@@ -10,7 +10,7 @@ Identity operator
 =======================#
 include("identity.jl")
 
-export IdentityMultiple, I
+export IdentityMultiple, Id
 
 #=========================
 Abstract Types for Systems

--- a/src/identity.jl
+++ b/src/identity.jl
@@ -25,8 +25,6 @@ size of the former is generic, the size of the latter is fixed.
 Only specifying the matrix size represents an identity matrix:
 
 ```jldoctest identitymultiple
-julia> using LinearAlgebra
-
 julia> using MathematicalSystems: IdentityMultiple
 
 julia> I2 = Id(2)
@@ -39,7 +37,7 @@ julia> 4*I2
 IdentityMultiple{Float64} of value 4.0 and order 2
 ```
 
-The numeric type (default `Float64`) can be passed as a second argument:
+The scaling (default `1.0`) can be passed as the second argument:
 
 ```jldoctest identitymultiple
 julia> I2r = Id(2, 1//1)
@@ -52,20 +50,11 @@ julia> 4*I2r
 IdentityMultiple{Rational{Int64}} of value 4//1 and order 2
 ```
 
-To create the matrix with a value different from the default (`1.0`), there are
-two ways. Either pass the value through the `Id` function, as in:
+Alternatively, use the constructor passing the `UniformScaling` (`I`):
 
 ```jldoctest identitymultiple
-julia> I2 = Id(2, 2.0)
-IdentityMultiple{Float64} of value 2.0 and order 2
+julia> using LinearAlgebra
 
-julia> I2r = Id(2, 2//1)
-IdentityMultiple{Rational{Int64}} of value 2//1 and order 2
-```
-
-Or use the constructor passing the `UniformScaling` (`I`):
-
-```jldoctest identitymultiple
 julia> I2 = IdentityMultiple(2.0*I, 2)
 IdentityMultiple{Float64} of value 2.0 and order 2
 

--- a/src/identity.jl
+++ b/src/identity.jl
@@ -22,13 +22,14 @@ size of the former is generic, the size of the latter is fixed.
 
 ### Examples
 
-The easiest way to create an identity multiple is to use the callable version
-of `LinearAlgebra.I`:
+Only specifying the matrix size represents an identity matrix:
 
 ```jldoctest identitymultiple
+julia> using LinearAlgebra
+
 julia> using MathematicalSystems: IdentityMultiple
 
-julia> I2 = I(2)
+julia> I2 = Id(2)
 IdentityMultiple{Float64} of value 1.0 and order 2
 
 julia> I2 + I2
@@ -41,7 +42,7 @@ IdentityMultiple{Float64} of value 4.0 and order 2
 The numeric type (default `Float64`) can be passed as a second argument:
 
 ```jldoctest identitymultiple
-julia> I2r = I(2, Rational{Int})
+julia> I2r = Id(2, 1//1)
 IdentityMultiple{Rational{Int64}} of value 1//1 and order 2
 
 julia> I2r + I2r
@@ -52,13 +53,13 @@ IdentityMultiple{Rational{Int64}} of value 4//1 and order 2
 ```
 
 To create the matrix with a value different from the default (`1.0`), there are
-two ways. Either pass the value through the callable `I`, as in:
+two ways. Either pass the value through the `Id` function, as in:
 
 ```jldoctest identitymultiple
-julia> I2 = I(2.0, 2)
+julia> I2 = Id(2, 2.0)
 IdentityMultiple{Float64} of value 2.0 and order 2
 
-julia> I2r = I(2//1, 2)
+julia> I2r = Id(2, 2//1)
 IdentityMultiple{Rational{Int64}} of value 2//1 and order 2
 ```
 
@@ -166,12 +167,26 @@ function Base.show(io::IO, ::MIME"text/plain", 𝐼::IdentityMultiple{T}) where 
     print(io, "$(typeof(𝐼)) of value $(𝐼.M.λ) and order $(𝐼.n)")
 end
 
-# callable identity matrix given the size and the numeric type
-LinearAlgebra.I(n::Int, N::DataType=Float64) = IdentityMultiple(one(N)*I, n)
+"""
+    Id(n::Int, [λ]::Number=1.0)
+
+Convenience constructor of an [`IdentityMultiple`](@ref).
+
+### Input
+
+- `n` -- dimension
+- `λ` -- (optional; default: `1.0`) scaling factor
+
+### Output
+
+An `IdentityMultiple` of the given size and scaling factor.
+"""
+function Id(n::Int, λ::Number=1.0)
+    return IdentityMultiple(λ*I, n)
+end
 
 # callable identity matrix given the scaling factor and the size
 IdentityMultiple(λ::Number, n::Int) = IdentityMultiple(λ*I, n)
-LinearAlgebra.I(λ::Number, n::Int) = IdentityMultiple(λ*I, n)
 
 function LinearAlgebra.Hermitian(𝐼::IdentityMultiple)
     return Hermitian(Diagonal(fill(𝐼.M.λ, 𝐼.n)))

--- a/src/systems.jl
+++ b/src/systems.jl
@@ -15,7 +15,7 @@ for (Z, AZ) in ((:ContinuousIdentitySystem, :AbstractContinuousSystem),
         statedim(s::$Z) = s.statedim
         inputdim(s::$Z) = 0
         noisedim(s::$Z) = 0
-        state_matrix(s::$Z) = I(s.statedim)
+        state_matrix(s::$Z) = Id(s.statedim)
     end
     for T in [Z, Type{<:eval(Z)}]
         @eval begin
@@ -70,7 +70,7 @@ for (Z, AZ) in ((:ConstrainedContinuousIdentitySystem, :AbstractContinuousSystem
         inputdim(::$Z) = 0
         noisedim(::$Z) = 0
         stateset(s::$Z) = s.X
-        state_matrix(s::$Z) = I(s.statedim)
+        state_matrix(s::$Z) = Id(s.statedim)
     end
     for T in [Z, Type{<:eval(Z)}]
         @eval begin

--- a/test/@ivp.jl
+++ b/test/@ivp.jl
@@ -1,6 +1,6 @@
 @testset "@ivp for a continuous system" begin
     P1 = @ivp(x' = -x, x(0) ∈ Interval(-1.0, 1.0))
-    testSystem = InitialValueProblem(LinearContinuousSystem(I(-1.0, 1)), Interval(-1, 1))
+    testSystem = InitialValueProblem(LinearContinuousSystem(Id(1, -1.0)), Interval(-1, 1))
     @test P1 == testSystem
     # throw error if x(0) is not defined
     @test_throws ArgumentError @ivp(x' = -x)

--- a/test/@system.jl
+++ b/test/@system.jl
@@ -120,11 +120,11 @@ end
     @test @system(w' = A*w + B*u_1 + c, w∈X, u_1∈U) == ConstrainedAffineControlContinuousSystem(A, B, c, X, U)
 
     # scalar cases
-    @test @system(x' = 0.5x + u) == LinearControlContinuousSystem(hcat(0.5), I(1.0, 1))
+    @test @system(x' = 0.5x + u) == LinearControlContinuousSystem(hcat(0.5), Id(1, 1.0))
     @test @system(x' = 0.5x + 1.) == AffineContinuousSystem(hcat(0.5), vcat(1.))
-    @test @system(x' = x + u) == LinearControlContinuousSystem(I(1.0, 1), I(1.0, 1))
-    @test @system(x' = x + 0.1u) == LinearControlContinuousSystem(I(1.0, 1), hcat(0.1))
-    @test @system(x' = x + 0.1*u) == LinearControlContinuousSystem(I(1.0, 1), hcat(0.1))
+    @test @system(x' = x + u) == LinearControlContinuousSystem(Id(1, 1.0), Id(1, 1.0))
+    @test @system(x' = x + 0.1u) == LinearControlContinuousSystem(Id(1, 1.0), hcat(0.1))
+    @test @system(x' = x + 0.1*u) == LinearControlContinuousSystem(Id(1, 1.0), hcat(0.1))
     sys = @system(x' = 0.3x + 0.1u + 0.2, x∈X, u∈U)
     @test sys == ConstrainedAffineControlContinuousSystem(hcat(0.3), hcat(0.1), vcat(0.2), X, U)
 end
@@ -140,7 +140,7 @@ end
 
 @testset "@system for affine continuous systems" begin
     b = [1.0]
-    @test @system(x' = x + b) == AffineContinuousSystem(I(1), b)
+    @test @system(x' = x + b) == AffineContinuousSystem(Id(1), b)
     @test @system(x' = A*x + c) == AffineContinuousSystem(A, c)
     sys =  @system(z_1' = A*z_1 + B*v_1 + c1, z_1 ∈ X, v_1 ∈ U1, input:v_1)
     @test sys == ConstrainedAffineControlContinuousSystem(A, B, c1, X, U1)
@@ -288,12 +288,12 @@ end
 @testset "@system with for an initial-value problem" begin
     # continuous ivp in floating-point
     ivp = @system(x' = -1.0x, x(0) ∈ Interval(-1, 1))
-    @test ivp == IVP(LinearContinuousSystem(I(-1.0, 1)), Interval(-1, 1)) &&
+    @test ivp == IVP(LinearContinuousSystem(Id(1, -1.0)), Interval(-1, 1)) &&
           eltype(ivp.s.A) == Float64
 
     # discrete ivp in floating-point
     ivp = @system(x⁺ = -x, x(0) ∈ [1])
-    @test ivp == IVP(LinearDiscreteSystem(I(-1.0, 1)), [1]) &&
+    @test ivp == IVP(LinearDiscreteSystem(Id(1, -1.0)), [1]) &&
           eltype(ivp.s.A) == Float64
 
     # initial state assignment doesn't match state variable

--- a/test/continuous.jl
+++ b/test/continuous.jl
@@ -35,7 +35,7 @@ As = [a][:,:]; Bs = [b][:,:]; Cs = [c]; Ds = [d][:,:]; Es = [e][:,:]
 
 @testset "Continuous identity system" begin
     s = ContinuousIdentitySystem(sd)
-    @test state_matrix(s) == I(sd)
+    @test state_matrix(s) == Id(sd)
     @test input_matrix(s) == nothing
     @test affine_term(s) == nothing
     @test noise_matrix(s) == nothing
@@ -53,7 +53,7 @@ end
 
 @testset "Continuous constrained identity system" begin
     s = ConstrainedContinuousIdentitySystem(sd, X)
-    @test state_matrix(s) == I(sd)
+    @test state_matrix(s) == Id(sd)
     @test input_matrix(s) == nothing
     @test affine_term(s) == nothing
     @test noise_matrix(s) == nothing

--- a/test/discrete.jl
+++ b/test/discrete.jl
@@ -33,7 +33,7 @@ As = [a][:,:]; Bs = [b][:,:]; Cs = [c]; Ds = [d][:,:]; Es = [e][:,:]
 
 @testset "Discrete identity system" begin
     s = DiscreteIdentitySystem(sd)
-    @test state_matrix(s) == I(sd)
+    @test state_matrix(s) == Id(sd)
     @test input_matrix(s) == nothing
     @test affine_term(s) == nothing
     @test noise_matrix(s) == nothing
@@ -51,7 +51,7 @@ end
 
 @testset "Discrete constrained identity system" begin
     s = ConstrainedDiscreteIdentitySystem(sd, X)
-    @test state_matrix(s) == I(sd)
+    @test state_matrix(s) == Id(sd)
     @test input_matrix(s) == nothing
     @test affine_term(s) == nothing
     @test noise_matrix(s) == nothing

--- a/test/identity.jl
+++ b/test/identity.jl
@@ -10,10 +10,10 @@
         @test In[1, 1] == 1.0 && In[1, 2] == 0.0
     end
 
-    @test I(3, 3) == IdentityMultiple(3I, 3)
+    @test Id(3, 4) == IdentityMultiple(4I, 3)
 
-    @test_throws ArgumentError I(-1)
-    @test_throws ArgumentError I(1, 0)
+    @test_throws ArgumentError Id(-1)
+    @test_throws ArgumentError Id(0, 1)
 end
 
 @testset "Operations between identity multiples" begin
@@ -34,7 +34,7 @@ end
     A, B = rand(4, 4), rand(4, 2)
     X = rand(Hyperrectangle, dim=4)
     U = rand(Ball2, dim=2)
-    I4 = I(4)
+    I4 = Id(4)
     s = ConstrainedLinearControlContinuousSystem(A, I4, X, B*U);
 
     @test statedim(s) == 4
@@ -42,7 +42,7 @@ end
 end
 
 @testset "Matrix operations for identity multiple" begin
-    I2 = I(2)
+    I2 = Id(2)
     @test getindex(I2, 1) == 1.
     @test getindex(I2, 2) == 0.
     @test getindex(I2, 3) == 0.
@@ -52,14 +52,14 @@ end
     A = I2 * rand(2, 2)
     @test A isa Matrix && size(A) == (2, 2)
 
-    @test I(2) / I == IdentityMultiple(1.0, 2)
-    @test I(2) - I(2) == 0.0I(2)
+    @test Id(2) / I == IdentityMultiple(1.0, 2)
+    @test Id(2) - Id(2) == 0.0Id(2)
 
-    @test I(2) + [3 3; 1 2] == [4 3; 1 3.]
-    @test [3 3; 1 2] + I(2) == [4 3; 1 3.]
+    @test Id(2) + [3 3; 1 2] == [4 3; 1 3.]
+    @test [3 3; 1 2] + Id(2) == [4 3; 1 3.]
 end
 
 @testset "Specific methods for IdentityMultiple" begin
-    @test Hermitian(I(2)) == Hermitian([1. 0; 0 1])
-    @test exp(I(1, 3)) == I(exp(1), 3)
+    @test Hermitian(Id(2)) == Hermitian([1. 0; 0 1])
+    @test exp(Id(3, 1)) == Id(3, exp(1))
 end

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -2,7 +2,7 @@
     n = 3
     A = rand(2, 2);
     b = rand(2)
-    identitymap = @map x -> I(n)*x
+    identitymap = @map x -> Id(n)*x
     @test identitymap == MathematicalSystems.IdentityMap(n)
     linearmap = @map x -> A*x
     @test linearmap == MathematicalSystems.LinearMap(A)


### PR DESCRIPTION
This is a proposal for #246.

- rename `I` → `Id`
- change signature from `I(λ, n)` and `I(n, ntype)` to `Id(n, λ)` (argument: the `ntype` method is redundant because you can just write `one(ntype)`, and I found it difficult to remember the order of arguments.)