### PR TITLE
Do not overwrite Base defaults with the same value

### DIFF
--- a/src/inputs.jl
+++ b/src/inputs.jl
@@ -72,7 +72,9 @@ end
 Base.eltype(::Type{ConstantInput{UT}}) where {UT} = UT
 Base.iterate(input::ConstantInput, state::Union{Int, Nothing}=nothing) = (input.U, nothing)
 Base.IteratorSize(::Type{<:ConstantInput}) = Base.IsInfinite()
-Base.IteratorEltype(::Type{<:ConstantInput}) = Base.HasEltype()
+
+# the following does not need to be defined because it is the default:
+# Base.IteratorEltype(::Type{<:ConstantInput}) = Base.HasEltype()
 
 Base.map(f::Function, c::ConstantInput) = ConstantInput(f(c.U))
 
@@ -193,8 +195,9 @@ end
 
 Base.length(input::VaryingInput) = length(input.U)
 
-Base.IteratorSize(::Type{<:VaryingInput}) = Base.HasLength()
-Base.IteratorEltype(::Type{<:VaryingInput}) = Base.HasEltype()
+# the following do not need to be defined because they are the default:
+# Base.IteratorSize(::Type{<:VaryingInput}) = Base.HasLength()
+# Base.IteratorEltype(::Type{<:VaryingInput}) = Base.HasEltype()
 
 Base.map(f::Function, v::VaryingInput) = VaryingInput(f.(v.U))
 


### PR DESCRIPTION
I am not sure about this change myself.

I ran `@snoopr` and saw that these methods have a `Base` definition, so they should maybe only be redefined when the behavior is different. See the default description here: [`IteratorSize`](https://docs.julialang.org/en/v1/base/collections/#Base.IteratorSize), [`IteratorEltype`](https://docs.julialang.org/en/v1/base/collections/#Base.IteratorEltype)

#### Before this change

```julia
julia> using SnoopCompileCore

julia> invalidations = @snoopr using MathematicalSystems
10-element Vector{Any}:
 MethodInstance for Base.IteratorSize(::Type)
 "invalidate_mt_cache"
 MethodInstance for Base.IteratorEltype(::Type)
 "invalidate_mt_cache"
 MethodInstance for Base.IteratorEltype(::Type)
 "invalidate_mt_cache"
 MethodInstance for Base.IteratorEltype(::Type)
 "invalidate_mt_cache"
 MethodInstance for Base.IteratorEltype(::Type)
 "invalidate_mt_cache"
```

#### After this change

There is only one such method left (which is needed because it differs from the default):

```julia
julia> using SnoopCompileCore

julia> invalidations = @snoopr using MathematicalSystems
2-element Vector{Any}:
 MethodInstance for Base.IteratorSize(::Type)
 "invalidate_mt_cache"
```