### PR TITLE
General "black-box" types for output maps

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,25 +4,17 @@ import LazySets
 DocMeta.setdocmeta!(MathematicalSystems, :DocTestSetup,
                     :(using MathematicalSystems); recursive=true)
 
-makedocs(
-    sitename = "MathematicalSystems.jl",
-    modules = [MathematicalSystems],
-    format = Documenter.HTML(prettyurls = get(ENV, "CI", nothing) == "true",
-                             assets = ["assets/aligned.css"]),
-    strict = true,
-    pages = [
-        "Home" => "index.md",
-        "Manual" => Any["System types overview" => "man/systems.md"],
-        "Library" => Any[
-            "Types"     => "lib/types.md",
-            "Methods"   => "lib/methods.md",
-            "Internals" => "lib/internals.md"
-        ],
-        "About" => "about.md"
-    ]
-)
+makedocs(; sitename="MathematicalSystems.jl",
+         modules=[MathematicalSystems],
+         format=Documenter.HTML(; prettyurls=get(ENV, "CI", nothing) == "true",
+                                assets=["assets/aligned.css"]),
+         strict=true,
+         pages=["Home" => "index.md",
+                "Manual" => Any["System types overview" => "man/systems.md"],
+                "Library" => Any["Types"     => "lib/types.md",
+                                 "Methods"   => "lib/methods.md",
+                                 "Internals" => "lib/internals.md"],
+                "About" => "about.md"])
 
-deploydocs(
-    repo = "github.com/JuliaReach/MathematicalSystems.jl.git",
-    push_preview = true
-)
+deploydocs(; repo="github.com/JuliaReach/MathematicalSystems.jl.git",
+           push_preview=true)

--- a/docs/src/lib/types.md
+++ b/docs/src/lib/types.md
@@ -156,6 +156,10 @@ AffineControlMap
 ConstrainedAffineControlMap
 ResetMap
 ConstrainedResetMap
+BlackBoxMap
+ConstrainedBlackBoxMap
+BlackBoxControlMap
+ConstrainedBlackBoxControlMap
 ```
 
 ### Macros

--- a/src/MathematicalSystems.jl
+++ b/src/MathematicalSystems.jl
@@ -162,7 +162,11 @@ export AbstractMap,
        AffineControlMap,
        ConstrainedAffineControlMap,
        ResetMap,
-       ConstrainedResetMap
+       ConstrainedResetMap, 
+       BlackBoxMap, 
+       ConstrainedBlackBoxMap, 
+       BlackBoxControlMap, 
+       ConstrainedBlackBoxControlMap
 
 # methods
 export outputmap,

--- a/src/MathematicalSystems.jl
+++ b/src/MathematicalSystems.jl
@@ -162,10 +162,10 @@ export AbstractMap,
        AffineControlMap,
        ConstrainedAffineControlMap,
        ResetMap,
-       ConstrainedResetMap, 
-       BlackBoxMap, 
-       ConstrainedBlackBoxMap, 
-       BlackBoxControlMap, 
+       ConstrainedResetMap,
+       BlackBoxMap,
+       ConstrainedBlackBoxMap,
+       BlackBoxControlMap,
        ConstrainedBlackBoxControlMap
 
 # methods

--- a/src/maps.jl
+++ b/src/maps.jl
@@ -418,7 +418,7 @@ A constrained black-box map of the form,
 - `h` -- output function
 - `X` -- state constraints
 """
-struct ConstrainedBlackBoxMap{FT, ST} <: AbstractMap
+struct ConstrainedBlackBoxMap{FT,ST} <: AbstractMap
     dim::Int
     output_dim::Int
     h::FT
@@ -481,7 +481,7 @@ A constrained black-box control map of the form,
 - `X` -- state constraints
 - `U` -- input constraints
 """
-struct ConstrainedBlackBoxControlMap{FT, ST, UT} <: AbstractMap
+struct ConstrainedBlackBoxControlMap{FT,ST,UT} <: AbstractMap
     dim::Int
     input_dim::Int
     output_dim::Int

--- a/src/maps.jl
+++ b/src/maps.jl
@@ -27,7 +27,7 @@ apply(m::IdentityMap, x) = x
 An identity map with state constraints of the form:
 
 ```math
-    x ↦ x, x(t) ∈ \\mathcal{X}.
+    x ↦ x, x ∈ \\mathcal{X}.
 ```
 
 ### Fields
@@ -76,7 +76,7 @@ apply(m::LinearMap, x) = m.A * x
 A linear map with state constraints of the form:
 
 ```math
-    x ↦ Ax, x(t) ∈ \\mathcal{X}.
+    x ↦ Ax, x ∈ \\mathcal{X}.
 ```
 
 ### Fields
@@ -131,7 +131,7 @@ apply(m::AffineMap, x) = m.A * x + m.c
 An affine map with state constraints of the form:
 
 ```math
-    x ↦ Ax + c, x(t) ∈ \\mathcal{X}.
+    x ↦ Ax + c, x ∈ \\mathcal{X}.
 ```
 
 ### Fields
@@ -373,3 +373,128 @@ function apply(m::Union{ResetMap,ConstrainedResetMap}, x)
     end
     return y
 end
+
+"""
+    BlackBoxMap
+
+A black-box map of the form,
+
+```math
+    x ↦ h(x).
+```
+
+### Fields
+
+- `dim`  -- state dimension
+- `output_dim` -- output dimension
+- `h` -- output function
+"""
+struct BlackBoxMap{FT} <: AbstractMap
+    dim::Int
+    output_dim::Int
+    h::FT
+end
+
+statedim(m::BlackBoxMap) = m.dim
+inputdim(::BlackBoxMap) = 0
+outputdim(m::BlackBoxMap) = m.output_dim
+islinear(::BlackBoxMap) = false
+isaffine(::BlackBoxMap) = false
+apply(m::BlackBoxMap, x) = m.h(x)
+
+"""
+    ConstrainedBlackBoxMap
+
+A constrained black-box map of the form,
+
+```math
+    x ↦ h(x), x ∈ \\mathcal{X}.
+```
+
+### Fields
+
+- `dim`  -- state dimension
+- `output_dim` -- output dimension
+- `h` -- output function
+- `X` -- state constraints
+"""
+struct ConstrainedBlackBoxMap{FT, ST} <: AbstractMap
+    dim::Int
+    output_dim::Int
+    h::FT
+    X::ST
+end
+
+statedim(m::ConstrainedBlackBoxMap) = m.dim
+stateset(m::ConstrainedBlackBoxMap) = m.X
+inputdim(::ConstrainedBlackBoxMap) = 0
+outputdim(m::ConstrainedBlackBoxMap) = m.output_dim
+islinear(::ConstrainedBlackBoxMap) = false
+isaffine(::ConstrainedBlackBoxMap) = false
+apply(m::ConstrainedBlackBoxMap, x) = m.h(x)
+
+"""
+    BlackBoxControlMap
+
+A black-box control map of the form,
+
+```math
+    (x, u) ↦ h(x, u).
+```
+
+### Fields
+
+- `dim`  -- state dimension
+- `input_dim` -- input dimension
+- `output_dim` -- output dimension
+- `h` -- output function
+"""
+struct BlackBoxControlMap{FT} <: AbstractMap
+    dim::Int
+    input_dim::Int
+    output_dim::Int
+    h::FT
+end
+
+statedim(m::BlackBoxControlMap) = m.dim
+inputdim(m::BlackBoxControlMap) = m.input_dim
+outputdim(m::BlackBoxControlMap) = m.output_dim
+islinear(::BlackBoxControlMap) = false
+isaffine(::BlackBoxControlMap) = false
+apply(m::BlackBoxControlMap, x, u) = m.h(x, u)
+
+"""
+    ConstrainedBlackBoxControlMap
+
+A constrained black-box control map of the form,
+
+```math
+    (x, u) ↦ h(x, u), x ∈ \\mathcal{X}, u ∈ \\mathcal{U}.
+```
+
+### Fields
+
+- `dim`  -- state dimension
+- `input_dim` -- input dimension
+- `output_dim` -- output dimension
+- `h` -- output function
+- `X` -- state constraints
+- `U` -- input constraints
+"""
+struct ConstrainedBlackBoxControlMap{FT, ST, UT} <: AbstractMap
+    dim::Int
+    input_dim::Int
+    output_dim::Int
+    h::FT
+    X::ST
+    U::UT
+end
+
+statedim(m::ConstrainedBlackBoxControlMap) = m.dim
+stateset(m::ConstrainedBlackBoxControlMap) = m.X
+inputdim(m::ConstrainedBlackBoxControlMap) = m.input_dim
+inputset(m::ConstrainedBlackBoxControlMap) = m.U
+outputdim(m::ConstrainedBlackBoxControlMap) = m.output_dim
+islinear(::ConstrainedBlackBoxControlMap) = false
+isaffine(::ConstrainedBlackBoxControlMap) = false
+apply(m::ConstrainedBlackBoxControlMap, x, u) = m.h(x, u)

--- a/test/maps.jl
+++ b/test/maps.jl
@@ -221,7 +221,7 @@ end
 end
 
 @testset "Black-box control map" begin
-    h(x, u) = [x[1] * x[2] + u, x[2] * x[3]] 
+    h(x, u) = [x[1] * x[2] + u, x[2] * x[3]]
 
     m = BlackBoxControlMap(3, 1, 2, h)
     @test statedim(m) == 3
@@ -233,7 +233,7 @@ end
 end
 
 @testset "Constrained black-box control map" begin
-    h(x, u) = [x[1] * x[2] + u, x[2] * x[3]] 
+    h(x, u) = [x[1] * x[2] + u, x[2] * x[3]]
     X = BallInf(zeros(3), 1.0)
     U = Interval(0, 5)
 

--- a/test/maps.jl
+++ b/test/maps.jl
@@ -193,3 +193,57 @@ end
     x = zeros(10)
     @test apply(m, x) == [0, -1.0, 0, 0, 1.0, 0, 0, 0, 0, 0]
 end
+
+@testset "Black-box map" begin
+    h(x) = [x[1] * x[2], x[2] * x[3]]
+
+    m = BlackBoxMap(3, 2, h)
+    @test statedim(m) == 3
+    @test inputdim(m) == 0
+    @test outputdim(m) == 2
+    @test islinear(m) == false
+    @test isaffine(m) == false
+    @test apply(m, [2, 3, 4]) == [6, 12]
+end
+
+@testset "Constrained black-box map" begin
+    h(x) = [x[1] * x[2], x[2] * x[3]]
+    X = BallInf(zeros(3), 1.0)
+
+    m = ConstrainedBlackBoxMap(3, 2, h, X)
+    @test statedim(m) == 3
+    @test inputdim(m) == 0
+    @test outputdim(m) == 2
+    @test islinear(m) == false
+    @test isaffine(m) == false
+    @test apply(m, [2, 3, 4]) == [6, 12]
+    @test stateset(m) == X
+end
+
+@testset "Black-box control map" begin
+    h(x, u) = [x[1] * x[2] + u, x[2] * x[3]] 
+
+    m = BlackBoxControlMap(3, 1, 2, h)
+    @test statedim(m) == 3
+    @test inputdim(m) == 1
+    @test outputdim(m) == 2
+    @test islinear(m) == false
+    @test isaffine(m) == false
+    @test apply(m, [2, 3, 4], 4) == [10, 12]
+end
+
+@testset "Constrained black-box control map" begin
+    h(x, u) = [x[1] * x[2] + u, x[2] * x[3]] 
+    X = BallInf(zeros(3), 1.0)
+    U = Interval(0, 5)
+
+    m = ConstrainedBlackBoxControlMap(3, 1, 2, h, X, U)
+    @test statedim(m) == 3
+    @test inputdim(m) == 1
+    @test outputdim(m) == 2
+    @test islinear(m) == false
+    @test isaffine(m) == false
+    @test apply(m, [2, 3, 4], 4) == [10, 12]
+    @test stateset(m) == X
+    @test inputset(m) == U
+end

--- a/test/vector_field.jl
+++ b/test/vector_field.jl
@@ -182,7 +182,7 @@ end
     plot(args...; kwargs...) = RecipesBase.apply_recipe(dict, args...; kwargs...)
     RecipesBase.is_key_supported(::Symbol) = true
 
-    f(x) = [2*x[2], -x[1]]
+    f(x) = [2 * x[2], -x[1]]
     VF = MathematicalSystems.VectorField(f)
     plot(VF)
 end


### PR DESCRIPTION
This PR follows this discussion: https://github.com/dionysos-dev/Dionysos.jl/issues/236. We feel like a general type for output maps is missing right now in MathematicalSystems.jl. 

Therefore, this PR implements four new types: 
- `BlackBoxMap`, a general type for output maps
- `ConstrainedBlackBoxMap`, a general type for output maps in which the state-space is constrained
- `BlackBoxControlMap`, a general type for control output maps
- `ConstrainedBlackBoxControlMap`, a general type for control output maps in which the state-space and input-space are constrained

These should be covered by the tests written in the PR, and the doc should be clean as well. 

@blegat 