### PR TITLE
Fix unbound args

### DIFF
--- a/src/maps.jl
+++ b/src/maps.jl
@@ -329,7 +329,7 @@ islinear(::ResetMap) = false
 isaffine(::ResetMap) = true
 
 # convenience constructor for a list of pairs instead of a dictionary
-ResetMap(dim::Int, args::Pair{Int,<:N}...) where {N} = ResetMap(dim, Dict{Int,N}(args))
+ResetMap(dim::Int, args::Pair{Int}...) = ResetMap(dim, Dict(args))
 
 """
     ConstrainedResetMap
@@ -362,8 +362,8 @@ islinear(::ConstrainedResetMap) = false
 isaffine(::ConstrainedResetMap) = true
 
 # convenience constructor for a list of pairs instead of a dictionary
-function ConstrainedResetMap(dim::Int, X, args::Pair{Int,<:N}...) where {N}
-    return ConstrainedResetMap(dim, X, Dict{Int,N}(args))
+function ConstrainedResetMap(dim::Int, X, args::Pair{Int}...)
+    return ConstrainedResetMap(dim, X, Dict(args))
 end
 
 function apply(m::Union{ResetMap,ConstrainedResetMap}, x)

--- a/test/Aqua.jl
+++ b/test/Aqua.jl
@@ -2,15 +2,8 @@ using MathematicalSystems, Test
 import Aqua
 
 @testset "Aqua tests" begin
-    @static if VERSION < v"1.6"
-        unbound_args = true
-    else
-        # the unbound args should be resolved in the future
-        unbound_args = (broken=true,)
-    end
-
     Aqua.test_all(MathematicalSystems;
-                  ambiguities=false, unbound_args=unbound_args)
+                  ambiguities=false)
 
     @static if VERSION < v"1.6"
         # do not warn about ambiguities in dependencies

--- a/test/maps.jl
+++ b/test/maps.jl
@@ -173,6 +173,8 @@ end
     @test !islinear(m) && isaffine(m)
     # alternative constructor from pairs
     @test m.dict == ResetMap(10, 2 => -1.0, 5 => 1.0).dict
+    # alternative constructor from pairs with mixed numeric types
+    @test ResetMap(10, 2 => -1.0, 5 => 1).dict == Dict(2 => -1.0, 5 => 1)
 
     # applying the affine map on a vector
     x = zeros(10)
@@ -196,6 +198,8 @@ end
     @test !islinear(m) && isaffine(m)
     # alternative constructor from pairs
     @test m.dict == ConstrainedResetMap(10, X, 2 => -1.0, 5 => 1.0).dict
+    # alternative constructor from pairs with mixed numeric types
+    @test ConstrainedResetMap(10, X, 2 => -1.0, 5 => 1).dict == Dict(2 => -1.0, 5 => 1)
 
     # applying the affine map on a vector
     x = zeros(10)

--- a/test/maps.jl
+++ b/test/maps.jl
@@ -165,10 +165,14 @@ end
     @test statedim(m) == 10
     @test inputdim(m) == 0
     @test outputdim(m) == 10
+    # alternative constructor from pairs
+    @test m.dict == ResetMap(10, 9 => 0.0).dict
 
-    m = ResetMap(10, 2 => -1.0, 5 => 1.0)
+    m = ResetMap(10, Dict(2 => -1.0, 5 => 1.0))
     @test outputdim(m) == 10
     @test !islinear(m) && isaffine(m)
+    # alternative constructor from pairs
+    @test m.dict == ResetMap(10, 2 => -1.0, 5 => 1.0).dict
 
     # applying the affine map on a vector
     x = zeros(10)
@@ -183,11 +187,15 @@ end
     @test inputdim(m) == 0
     @test outputdim(m) == 10
     @test stateset(m) == X
+    # alternative constructor from pairs
+    @test m.dict == ConstrainedResetMap(10, X, 9 => 0.0).dict
 
-    m = ConstrainedResetMap(10, X, 2 => -1.0, 5 => 1.0)
+    m = ConstrainedResetMap(10, X, Dict(2 => -1.0, 5 => 1.0))
     @test outputdim(m) == 10
     @test stateset(m) == X
     @test !islinear(m) && isaffine(m)
+    # alternative constructor from pairs
+    @test m.dict == ConstrainedResetMap(10, X, 2 => -1.0, 5 => 1.0).dict
 
     # applying the affine map on a vector
     x = zeros(10)


### PR DESCRIPTION
Closes #284.

The old code seemed to work with mixed types at first glance, but it did not. The type parameter `N` was not automatically inferred:

```julia
julia> ResetMap(10, Dict(2 => -1.0, 5 => 1))  # on master
ERROR: MethodError: no method matching ResetMap(::Int64, ::Pair{Int64, Float64}, ::Pair{Int64, Int64})
```

The new code works and fixes the unbound arg warning.

The tests only compare the `Dict` because we do not have `==` methods available.