### PR TITLE
Define helper functions in tests only once

### DIFF
--- a/test/continuous.jl
+++ b/test/continuous.jl
@@ -19,9 +19,6 @@ p = 2x^2 - 3x + y
 sdp = 2
 
 # blackbox system
-add_one(x) = x .+ 1
-add_one(x, u) = x .+ 1 .+ u
-add_one(x, u, w) = x .+ 1 .+ u .+ w
 state = [1.0; 2.0]
 input = 1
 noise = [3.0; 1.0]

--- a/test/discrete.jl
+++ b/test/discrete.jl
@@ -17,9 +17,6 @@ p = 2x^2 - 3x + y
 sdp = 2
 
 # blackbox system
-add_one(x) = x .+ 1
-add_one(x, u) = x .+ 1 .+ u
-add_one(x, u, w) = x .+ 1 .+ u .+ w
 state = [1.0; 2.0]
 input = 1
 noise = [3.0; 1.0]

--- a/test/helper_functions.jl
+++ b/test/helper_functions.jl
@@ -1,0 +1,3 @@
+add_one(x) = x .+ 1
+add_one(x, u) = x .+ 1 .+ u
+add_one(x, u, w) = x .+ 1 .+ u .+ w

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,7 @@ end
 @testset "Abstract systems" begin
     include("abstract.jl")
 end
+include("helper_functions.jl")
 @testset "Continuous systems" begin
     include("continuous.jl")
 end


### PR DESCRIPTION
There were function redefinitions in the tests, leading to the following warnings:

```julia
WARNING: Method definition add_one(Any) in module Main
 at /home/runner/work/MathematicalSystems.jl/MathematicalSystems.jl/test/continuous.jl:22
 overwritten at /home/runner/work/MathematicalSystems.jl/MathematicalSystems.jl/test/discrete.jl:20.
WARNING: Method definition add_one(Any, Any) in module Main
 at /home/runner/work/MathematicalSystems.jl/MathematicalSystems.jl/test/continuous.jl:23
 overwritten at /home/runner/work/MathematicalSystems.jl/MathematicalSystems.jl/test/discrete.jl:21.
WARNING: Method definition add_one(Any, Any, Any) in module Main
 at /home/runner/work/MathematicalSystems.jl/MathematicalSystems.jl/test/continuous.jl:24
 overwritten at /home/runner/work/MathematicalSystems.jl/MathematicalSystems.jl/test/discrete.jl:22.
```