### PR TITLE
`IdentityMultiple`: throw `BoundsError` for nonpositive index and use `@boundscheck`

### DIFF
--- a/src/identity.jl
+++ b/src/identity.jl
@@ -77,16 +77,13 @@ Base.IndexStyle(::Type{<:IdentityMultiple}) = IndexLinear()
 Base.size(𝐼::IdentityMultiple) = (𝐼.n, 𝐼.n)
 
 function Base.getindex(𝐼::IdentityMultiple, inds::Integer...)
-    all(idx -> 1 ≤ idx ≤ 𝐼.n, inds) || throw(BoundsError(𝐼, inds))
+    @boundscheck all(idx -> 1 ≤ idx ≤ 𝐼.n, inds) || throw(BoundsError(𝐼, inds))
     return getindex(𝐼.M, inds...)
 end
 
 function Base.getindex(𝐼::IdentityMultiple{T}, ind::Integer) where {T}
-    if 1 ≤ ind ≤ 𝐼.n^2
-        return rem(ind - 1, 𝐼.n + 1) == 0 ? 𝐼.M.λ : zero(T)
-    else
-        throw(BoundsError(𝐼, ind))
-    end
+    @boundscheck 1 ≤ ind ≤ 𝐼.n^2 || throw(BoundsError(𝐼, ind))
+    return rem(ind - 1, 𝐼.n + 1) == 0 ? 𝐼.M.λ : zero(T)
 end
 
 function Base.setindex!(::IdentityMultiple, ::Any, inds...)

--- a/src/identity.jl
+++ b/src/identity.jl
@@ -77,7 +77,7 @@ Base.IndexStyle(::Type{<:IdentityMultiple}) = IndexLinear()
 Base.size(𝐼::IdentityMultiple) = (𝐼.n, 𝐼.n)
 
 function Base.getindex(𝐼::IdentityMultiple, inds::Integer...)
-    any(idx -> idx > 𝐼.n, inds) && throw(BoundsError(𝐼, inds))
+    all(idx -> 1 ≤ idx ≤ 𝐼.n, inds) || throw(BoundsError(𝐼, inds))
     return getindex(𝐼.M, inds...)
 end
 

--- a/test/identity.jl
+++ b/test/identity.jl
@@ -4,7 +4,9 @@
     @test size(I1) == (1, 1)
     @test I1[1, 1] == 1.0
     @test_throws BoundsError I1[1, 2]
+    @test_throws BoundsError I1[1, 0]
     @test_throws BoundsError I1[3]
+    @test_throws BoundsError I1[0]
     @test_throws ErrorException I1[1] = 2
 
     for n in [2, 1000]


### PR DESCRIPTION
Closes #184.

The second commit restructures the code to use the `@boundscheck` annotation as described [here](https://docs.julialang.org/en/v1/devdocs/boundscheck/).