### PR TITLE
Use latest version of JuliaFormatter again

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Cache artifacts
         uses: julia-actions/cache@v3
       - name: Install JuliaFormatter and format
-        run: julia -e 'import Pkg; Pkg.add(name="JuliaFormatter", version=v"1.0.62"); using JuliaFormatter; format(".")'
+        run: julia -e 'import Pkg; Pkg.add("JuliaFormatter"); using JuliaFormatter; format(".")'
       - name: Create pull request
         id: cpr
         uses: peter-evans/create-pull-request@v8

--- a/src/identity.jl
+++ b/src/identity.jl
@@ -131,7 +131,8 @@ end
 
 # right-division
 # beside `AbstractMatrix`, we need some disambiguations with LinearAlgebra since v1.6
-for M in (:AbstractMatrix, :(Transpose{<:Any,<:AbstractVector}), :(Adjoint{<:Any,<:AbstractVector}))
+for M in
+    (:AbstractMatrix, :(Transpose{<:Any,<:AbstractVector}), :(Adjoint{<:Any,<:AbstractVector}))
     @eval begin
         function Base.:(/)(A::$M, 𝐼::IdentityMultiple)
             size(A, 2) != 𝐼.n && throw(DimensionMismatch("incompatible dimensions"))

--- a/test/discretize.jl
+++ b/test/discretize.jl
@@ -35,7 +35,7 @@ end
 
     # get affine ctypes
     CTYPES = filter(x -> (occursin("Linear", string(x)) || occursin("Affine", string(x))) &&
-                        !occursin("Descriptor", string(x)), subtypes(AbstractContinuousSystem))
+                         !occursin("Descriptor", string(x)), subtypes(AbstractContinuousSystem))
 
     # this test doesn't apply for second order systems and parametric systems
     filter!(x -> x ∉ SECOND_ORDER_CTYPES && !isparametric(x), CTYPES)
@@ -76,7 +76,7 @@ end
 
     # get affine ctypes
     CTYPES = filter(x -> (occursin("Linear", string(x)) || occursin("Affine", string(x))) &&
-                        !occursin("Descriptor", string(x)), subtypes(AbstractContinuousSystem))
+                         !occursin("Descriptor", string(x)), subtypes(AbstractContinuousSystem))
 
     # this test doesn't apply for second order systems and parametric systems
     filter!(x -> x ∉ SECOND_ORDER_CTYPES && !isparametric(x), CTYPES)


### PR DESCRIPTION
The latest JuliaFormatter behavior is sufficiently similar to v1. See #322.